### PR TITLE
Remove unused CredentialType

### DIFF
--- a/credential-exchange-types/src/format.rs
+++ b/credential-exchange-types/src/format.rs
@@ -154,22 +154,6 @@ pub enum Extension<E = ()> {
     Unknown(serde_json::Value),
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "kebab-case")]
-pub enum CredentialType {
-    BasicAuth,
-    Passkey,
-    Totp,
-    CryptographicKey,
-    Note,
-    File,
-    Address,
-    CreditCard,
-    SocialSecurityNumber,
-    #[serde(untagged)]
-    Unknown(String),
-}
-
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum Credential {
@@ -208,19 +192,6 @@ pub enum Credential {
         #[serde(flatten)]
         content: serde_json::Map<String, serde_json::Value>,
     },
-}
-
-impl From<Credential> for CredentialType {
-    fn from(value: Credential) -> Self {
-        match value {
-            Credential::BasicAuth(_) => CredentialType::BasicAuth,
-            Credential::Passkey(_) => CredentialType::Passkey,
-            Credential::CreditCard { .. } => CredentialType::CreditCard,
-            Credential::Note { .. } => CredentialType::Note,
-            Credential::Totp { .. } => CredentialType::Totp,
-            Credential::Unknown { ty, .. } => CredentialType::Unknown(ty),
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/credential-exchange-types/src/format.rs
+++ b/credential-exchange-types/src/format.rs
@@ -156,7 +156,7 @@ pub enum Extension<E = ()> {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
-enum CredentialType {
+pub enum CredentialType {
     BasicAuth,
     Passkey,
     Totp,

--- a/credential-exchange-types/src/format.rs
+++ b/credential-exchange-types/src/format.rs
@@ -154,7 +154,7 @@ pub enum Extension<E = ()> {
     Unknown(serde_json::Value),
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
 enum CredentialType {
     BasicAuth,
@@ -208,6 +208,19 @@ pub enum Credential {
         #[serde(flatten)]
         content: serde_json::Map<String, serde_json::Value>,
     },
+}
+
+impl From<Credential> for CredentialType {
+    fn from(value: Credential) -> Self {
+        match value {
+            Credential::BasicAuth(_) => CredentialType::BasicAuth,
+            Credential::Passkey(_) => CredentialType::Passkey,
+            Credential::CreditCard { .. } => CredentialType::CreditCard,
+            Credential::Note { .. } => CredentialType::Note,
+            Credential::Totp { .. } => CredentialType::Totp,
+            Credential::Unknown { ty, .. } => CredentialType::Unknown(ty),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Remove the unused `CredentialType` enum. Lifting the Bitwarden specific usage into sdk-internal.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
