### PR TITLE
Change creation and modified dates of item to optional

### DIFF
--- a/credential-exchange-types/src/format.rs
+++ b/credential-exchange-types/src/format.rs
@@ -91,10 +91,18 @@ pub struct Item<E = ()> {
     /// A unique identifier for the [Item] which is machine generated and an opaque byte sequence
     /// with a maximum size of 64 bytes. It SHOULD NOT be displayed to the user.
     pub id: B64Url,
-    /// The UNIX timestamp in seconds at which this item was originally created.
-    pub creation_at: u64,
-    /// The UNIX timestamp in seconds of the last modification brought to this [Item].
-    pub modified_at: u64,
+    /// The OPTIONAL member contains the UNIX timestamp in seconds at which this item was
+    /// originally created. If this member is not set, but the importing provider requires this
+    /// member in their proprietary data model, the importer SHOULD use the current timestamp
+    /// at the time the provider encounters this [Item].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub creation_at: Option<u64>,
+    /// This OPTIONAL member contains the UNIX timestamp in seconds of the last modification
+    /// brought to this [Item]. If this member is not set, but the importing provider requires
+    /// this member in their proprietary data model, the importer SHOULD use the current
+    /// timestamp at the time the provider encounters this [Item].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modified_at: Option<u64>,
     /// This member contains a hint to the objects in the credentials array. It SHOULD be a member
     /// of [ItemType].
     #[serde(rename = "type")]


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The `creation_at` and `modified_at` fields for `Item` are now optional in the spec.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
