### PR TITLE
Strongly typed editable fields

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
   "version": "0.2",
-  "words": ["Bitwarden"],
+  "words": [
+    "Bitwarden",
+    "Totp"
+  ],
   "flagWords": [],
   "ignorePaths": [
     ".vscode",

--- a/credential-exchange-types/src/format.rs
+++ b/credential-exchange-types/src/format.rs
@@ -1,7 +1,8 @@
-use serde::{de::DeserializeOwned, ser::SerializeStruct, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 pub use self::{
     document::{FileCredential, NoteCredential},
+    editable_field::*,
     identity::{
         AddressCredential, CreditCardCredential, DriversLicenseCredential,
         IdentityDocumentCredential, PassportCredential, PersonNameCredential,
@@ -15,6 +16,7 @@ pub use self::{
 use crate::b64url::B64Url;
 
 mod document;
+mod editable_field;
 mod identity;
 mod login;
 mod passkey;
@@ -212,165 +214,4 @@ pub struct ItemReferenceCredential {
     /// [Account]. However, the other item MAY NOT be in the exchange if it is owned by a different
     /// account and shared with the currenly exchanged account.
     pub reference: LinkedItem,
-}
-
-#[derive(Clone, Debug)]
-pub struct EditableField<T: EditableFieldType + Serialize + DeserializeOwned> {
-    /// A unique identifier for the [EditableField] which is machine generated and an opaque byte
-    /// sequence with a maximum size of 64 bytes. It SHOULD NOT be displayed to the user.
-    pub id: Option<B64Url>,
-    /// This member defines the meaning of the [value][EditableField::value] member and its type.
-    /// This meaning is two-fold:
-    ///
-    /// 1. The string representation of the value if its native type is not a string.
-    /// 2. The UI representation used to display the value.
-    ///
-    /// The value SHOULD be a member of [FieldType] and the
-    /// [importing provider](https://fidoalliance.org/specs/cx/cxp-v1.0-wd-20241003.html#importing-provider)
-    /// SHOULD ignore any unknown values and default to [string][FieldType::String].
-    /// pub field_type: FieldType,
-    /// This member contains the [fieldType][EditableField::field_type] defined by the user.
-    pub value: T,
-    /// This member contains a user facing value describing the value stored. This value MAY be
-    /// user defined.
-    pub label: Option<String>,
-}
-
-impl<T> Serialize for EditableField<T>
-where
-    T: EditableFieldType + Serialize + DeserializeOwned,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("editable_field", 4)?;
-        if let Some(ref id) = self.id {
-            state.serialize_field("id", id)?;
-        }
-        state.serialize_field("value", &self.value)?;
-        state.serialize_field("field_type", &self.value.field_type())?;
-        if let Some(ref label) = self.label {
-            state.serialize_field("label", label)?;
-        }
-        state.end()
-    }
-}
-
-impl<'de, T> Deserialize<'de> for EditableField<T>
-where
-    T: EditableFieldType + Serialize + DeserializeOwned,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct EditableFieldHelper<T> {
-            id: Option<B64Url>,
-            value: T,
-            field_type: String,
-            label: Option<String>,
-        }
-
-        let helper = EditableFieldHelper::deserialize(deserializer)?;
-        Ok(Self {
-            id: helper.id,
-            value: helper.value,
-            label: helper.label,
-        })
-    }
-}
-
-pub trait EditableFieldType<T: Serialize + DeserializeOwned = Self> {
-    fn field_type(&self) -> &str;
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct EditableFieldString(String);
-impl EditableFieldType for EditableFieldString {
-    fn field_type(&self) -> &str {
-        "string"
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct EditableFieldConcealedString(String);
-impl EditableFieldType for EditableFieldConcealedString {
-    fn field_type(&self) -> &str {
-        "concealed-string"
-    }
-}
-
-fn serialize_bool<S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(if *value { "true" } else { "false" })
-}
-
-fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = String::deserialize(deserializer)?;
-    match value.as_str() {
-        "true" => Ok(true),
-        "false" => Ok(false),
-        _ => Err(serde::de::Error::custom("expected 'true' or 'false'")),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use serde_json::json;
-
-    use super::*;
-
-    #[test]
-    fn test_serialize_editable_field_string() {
-        let field = EditableField {
-            id: None,
-            value: EditableFieldString("value".to_string()),
-            label: Some("label".to_string()),
-        };
-        let json = json!({
-            "value": "value",
-            "field_type": "string",
-            "label": "label",
-        });
-        assert_eq!(serde_json::to_value(&field).unwrap(), json);
-    }
-
-    #[test]
-    fn test_serialize_editable_field_concealed_string() {
-        let field = EditableField {
-            id: None,
-            value: EditableFieldConcealedString("value".to_string()),
-            label: Some("label".to_string()),
-        };
-        let json = json!({
-            "field_type": "concealed-string",
-            "value": "value",
-            "label": "label",
-        });
-        assert_eq!(serde_json::to_value(&field).unwrap(), json);
-    }
-
-    /*
-    #[test]
-    fn test_serialize_editable_field_boolean() {
-        let field = EditableField {
-            id: None,
-            value: EditableFieldValue::Boolean(true),
-            label: Some("label".to_string()),
-        };
-        let json = json!({
-            "field_type": "boolean",
-            "value": "true",
-            "label": "label",
-        });
-        assert_eq!(serde_json::to_value(&field).unwrap(), json);
-    }
-    */
 }

--- a/credential-exchange-types/src/format.rs
+++ b/credential-exchange-types/src/format.rs
@@ -243,39 +243,36 @@ pub struct EditableField {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", tag = "field_type", content = "value")]
 pub enum EditableFieldValue {
+    /// A UTF-8 encoded string value which is unconcealed and does not have a specified format.
     String(String),
+    /// A UTF-8 encoded string value which should be considered secret and not displayed unless the
+    /// user explicitly requests it.
     ConcealedString(String),
+    /// A UTF-8 encoded string value which follows the format specified in
+    /// [RFC5322](https://www.rfc-editor.org/rfc/rfc5322#section-3.4). This field SHOULD be
+    /// unconcealed.
     Email(String),
+    /// A stringified numeric value which is unconcealed.
     Number(String),
+    /// A boolean value which is unconcealed. It MUST be of the values "true" or "false".
     #[serde(
         serialize_with = "serialize_bool",
         deserialize_with = "deserialize_bool"
     )]
     Boolean(bool),
-    Date(String),
-    #[serde(untagged)]
-    Unknown(String),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub enum FieldType {
-    /// A UTF-8 encoded string value which is unconcealed and does not have a specified format.
-    String,
-    /// A UTF-8 encoded string value which should be considered secret and not displayed unless the
-    /// user explicitly requests it.
-    ConcealedString,
-    /// A UTF-8 encoded string value which follows the format specified in
-    /// [RFC5322](https://www.rfc-editor.org/rfc/rfc5322#section-3.4). This field SHOULD be
-    /// unconcealed.
-    Email,
-    /// A stringified numeric value which is unconcealed.
-    Number,
-    /// A boolean value which is unconcealed. It MUST be of the values "true" or "false".
-    Boolean,
     /// A string value representing a calendar date which follows the format specified in
     /// [RFC3339](https://www.rfc-editor.org/rfc/rfc3339).
-    Date,
+    Date(String),
+    /// A string value representing a calendar date which follows the date-fullyear "-" date-month
+    /// pattern as established in [[!RFC3339#appendix-A]]. This is equivalent to the YYYY-MM format
+    /// specified in [ISO-8601].
+    YearMonth(String),
+    /// A string value representing a value that SHOULD be a member of WIFINetworkSecurityType.
+    WifiNetworkSecurityType(String),
+    /// A string value which MUST follow the [ISO3166-1] alpha-2 format.
+    CountryCode(String),
+    /// A string which MUST follow the [ISO3166-2] format.
+    SubdivisionCode(String),
     #[serde(untagged)]
     Unknown(String),
 }
@@ -301,8 +298,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn test_serialize_editable_field_string() {

--- a/credential-exchange-types/src/format.rs
+++ b/credential-exchange-types/src/format.rs
@@ -1,20 +1,6 @@
-use login::GeneratedPasswordCredential;
 use serde::{Deserialize, Serialize};
 
-pub use self::{
-    document::{FileCredential, NoteCredential},
-    editable_field::*,
-    identity::{
-        AddressCredential, CreditCardCredential, DriversLicenseCredential,
-        IdentityDocumentCredential, PassportCredential, PersonNameCredential,
-    },
-    login::{
-        ApiKeyCredential, BasicAuthCredential, OTPHashAlgorithm, SshKeyCredential, TotpCredential,
-    },
-    passkey::{
-        Fido2Extensions, Fido2HmacSecret, Fido2LargeBlob, Fido2SupplementalKeys, PasskeyCredential,
-    },
-};
+pub use self::{document::*, editable_field::*, identity::*, login::*, passkey::*};
 use crate::{b64url::B64Url, Uri};
 
 mod document;
@@ -203,29 +189,6 @@ pub struct ItemReferenceCredential {
     /// [Account]. However, the other item MAY NOT be in the exchange if it is owned by a different
     /// account and shared with the currenly exchanged account.
     pub reference: LinkedItem,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub enum FieldType {
-    /// A UTF-8 encoded string value which is unconcealed and does not have a specified format.
-    String,
-    /// A UTF-8 encoded string value which should be considered secret and not displayed unless the
-    /// user explicitly requests it.
-    ConcealedString,
-    /// A UTF-8 encoded string value which follows the format specified in
-    /// [RFC5322](https://www.rfc-editor.org/rfc/rfc5322#section-3.4). This field SHOULD be
-    /// unconcealed.
-    Email,
-    /// A stringified numeric value which is unconcealed.
-    Number,
-    /// A boolean value which is unconcealed. It MUST be of the values "true" or "false".
-    Boolean,
-    /// A string value representing a calendar date which follows the format specified in
-    /// [RFC3339](https://www.rfc-editor.org/rfc/rfc3339).
-    Date,
-    #[serde(untagged)]
-    Unknown(String),
 }
 
 /// This is an object that describes an appropriate context in which the [Item]'s

--- a/credential-exchange-types/src/format/document.rs
+++ b/credential-exchange-types/src/format/document.rs
@@ -4,13 +4,14 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::{EditableField, EditableFieldString};
 use crate::B64Url;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NoteCredential {
     /// This member is a user-defined value encoded as a UTF-8 string.
-    pub content: String,
+    pub content: EditableField<EditableFieldString>,
 }
 
 /// A [FileCredential] acts as a placeholder to an arbitrary binary file holding its associated

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -3,7 +3,7 @@ use serde::{de::DeserializeOwned, ser::SerializeStruct, Deserialize, Serialize};
 use crate::B64Url;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EditableField<T: EditableFieldType + Serialize + DeserializeOwned> {
+pub struct EditableField<T: EditableFieldType> {
     /// A unique identifier for the [EditableField] which is machine generated and an opaque byte
     /// sequence with a maximum size of 64 bytes. It SHOULD NOT be displayed to the user.
     pub id: Option<B64Url>,
@@ -26,7 +26,7 @@ pub struct EditableField<T: EditableFieldType + Serialize + DeserializeOwned> {
 
 impl<T> Serialize for EditableField<T>
 where
-    T: EditableFieldType + Serialize + DeserializeOwned,
+    T: EditableFieldType + Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -47,7 +47,7 @@ where
 
 impl<'de, T> Deserialize<'de> for EditableField<T>
 where
-    T: EditableFieldType + Serialize + DeserializeOwned,
+    T: EditableFieldType + DeserializeOwned,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -77,7 +77,7 @@ where
     }
 }
 
-pub trait EditableFieldType<T: Serialize + DeserializeOwned = Self> {
+pub trait EditableFieldType {
     fn field_type(&self) -> &str;
 }
 

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -118,7 +118,7 @@ where
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct EditableFieldString(String);
+pub struct EditableFieldString(pub String);
 impl EditableFieldType for EditableFieldString {
     fn field_type(&self) -> FieldType {
         FieldType::String
@@ -127,7 +127,7 @@ impl EditableFieldType for EditableFieldString {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct EditableFieldConcealedString(String);
+pub struct EditableFieldConcealedString(pub String);
 impl EditableFieldType for EditableFieldConcealedString {
     fn field_type(&self) -> FieldType {
         FieldType::ConcealedString
@@ -140,7 +140,7 @@ pub struct EditableFieldBoolean(
         serialize_with = "serialize_bool",
         deserialize_with = "deserialize_bool"
     )]
-    bool,
+    pub bool,
 );
 impl EditableFieldType for EditableFieldBoolean {
     fn field_type(&self) -> FieldType {
@@ -150,7 +150,7 @@ impl EditableFieldType for EditableFieldBoolean {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct EditableFieldDate(String);
+pub struct EditableFieldDate(pub String);
 impl EditableFieldType for EditableFieldDate {
     fn field_type(&self) -> FieldType {
         FieldType::Date
@@ -159,7 +159,7 @@ impl EditableFieldType for EditableFieldDate {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct EditableFieldYearMonth(String);
+pub struct EditableFieldYearMonth(pub String);
 impl EditableFieldType for EditableFieldYearMonth {
     fn field_type(&self) -> FieldType {
         FieldType::YearMonth
@@ -168,7 +168,7 @@ impl EditableFieldType for EditableFieldYearMonth {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct EditableFieldSubdivisionCode(String);
+pub struct EditableFieldSubdivisionCode(pub String);
 impl EditableFieldType for EditableFieldSubdivisionCode {
     fn field_type(&self) -> FieldType {
         FieldType::SubdivisionCode
@@ -177,7 +177,7 @@ impl EditableFieldType for EditableFieldSubdivisionCode {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct EditableFieldCountryCode(String);
+pub struct EditableFieldCountryCode(pub String);
 impl EditableFieldType for EditableFieldCountryCode {
     fn field_type(&self) -> FieldType {
         FieldType::CountryCode

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -34,8 +34,8 @@ pub enum FieldType {
     /// [RFC3339](https://www.rfc-editor.org/rfc/rfc3339).
     Date,
     /// A string value representing a calendar date which follows the date-fullyear "-" date-month
-    /// pattern as established in [RFC3339] Appendix A. This is equivalent to the YYYY-MM format
-    /// specified in [ISO-8601].
+    /// pattern as established in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) Appendix A.
+    /// This is equivalent to the YYYY-MM format specified in ISO8601.
     YearMonth,
     /// A string value representing a value that SHOULD be a member of WIFINetworkSecurityType.
     WifiNetworkSecurityType,

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -1,0 +1,177 @@
+use serde::{de::DeserializeOwned, ser::SerializeStruct, Deserialize, Serialize};
+
+use crate::B64Url;
+
+#[derive(Clone, Debug)]
+pub struct EditableField<T: EditableFieldType + Serialize + DeserializeOwned> {
+    /// A unique identifier for the [EditableField] which is machine generated and an opaque byte
+    /// sequence with a maximum size of 64 bytes. It SHOULD NOT be displayed to the user.
+    pub id: Option<B64Url>,
+    /// This member defines the meaning of the [value][EditableField::value] member and its type.
+    /// This meaning is two-fold:
+    ///
+    /// 1. The string representation of the value if its native type is not a string.
+    /// 2. The UI representation used to display the value.
+    ///
+    /// The value SHOULD be a member of [FieldType] and the
+    /// [importing provider](https://fidoalliance.org/specs/cx/cxp-v1.0-wd-20241003.html#importing-provider)
+    /// SHOULD ignore any unknown values and default to [string][FieldType::String].
+    /// pub field_type: FieldType,
+    /// This member contains the [fieldType][EditableField::field_type] defined by the user.
+    pub value: T,
+    /// This member contains a user facing value describing the value stored. This value MAY be
+    /// user defined.
+    pub label: Option<String>,
+}
+
+impl<T> Serialize for EditableField<T>
+where
+    T: EditableFieldType + Serialize + DeserializeOwned,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("editable_field", 4)?;
+        if let Some(ref id) = self.id {
+            state.serialize_field("id", id)?;
+        }
+        state.serialize_field("value", &self.value)?;
+        state.serialize_field("field_type", &self.value.field_type())?;
+        if let Some(ref label) = self.label {
+            state.serialize_field("label", label)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de, T> Deserialize<'de> for EditableField<T>
+where
+    T: EditableFieldType + Serialize + DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct EditableFieldHelper<T> {
+            id: Option<B64Url>,
+            value: T,
+            field_type: String,
+            label: Option<String>,
+        }
+
+        let helper = EditableFieldHelper::deserialize(deserializer)?;
+        Ok(Self {
+            id: helper.id,
+            value: helper.value,
+            label: helper.label,
+        })
+    }
+}
+
+pub trait EditableFieldType<T: Serialize + DeserializeOwned = Self> {
+    fn field_type(&self) -> &str;
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EditableFieldString(String);
+impl EditableFieldType for EditableFieldString {
+    fn field_type(&self) -> &str {
+        "string"
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EditableFieldConcealedString(String);
+impl EditableFieldType for EditableFieldConcealedString {
+    fn field_type(&self) -> &str {
+        "concealed-string"
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+
+pub struct EditableFieldBoolean(
+    #[serde(
+        serialize_with = "serialize_bool",
+        deserialize_with = "deserialize_bool"
+    )]
+    bool,
+);
+impl EditableFieldType for EditableFieldBoolean {
+    fn field_type(&self) -> &str {
+        "boolean"
+    }
+}
+
+fn serialize_bool<S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(if *value { "true" } else { "false" })
+}
+
+fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    match value.as_str() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(serde::de::Error::custom("expected 'true' or 'false'")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_serialize_editable_field_string() {
+        let field = EditableField {
+            id: None,
+            value: EditableFieldString("value".to_string()),
+            label: Some("label".to_string()),
+        };
+        let json = json!({
+            "value": "value",
+            "field_type": "string",
+            "label": "label",
+        });
+        assert_eq!(serde_json::to_value(&field).unwrap(), json);
+    }
+
+    #[test]
+    fn test_serialize_editable_field_concealed_string() {
+        let field = EditableField {
+            id: None,
+            value: EditableFieldConcealedString("value".to_string()),
+            label: Some("label".to_string()),
+        };
+        let json = json!({
+            "field_type": "concealed-string",
+            "value": "value",
+            "label": "label",
+        });
+        assert_eq!(serde_json::to_value(&field).unwrap(), json);
+    }
+
+    #[test]
+    fn test_serialize_editable_field_boolean() {
+        let field = EditableField {
+            id: None,
+            value: EditableFieldBoolean(true),
+            label: Some("label".to_string()),
+        };
+        let json = json!({
+            "field_type": "boolean",
+            "value": "true",
+            "label": "label",
+        });
+        assert_eq!(serde_json::to_value(&field).unwrap(), json);
+    }
+}

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -206,7 +206,7 @@ fn serialize_bool<S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str(if *value { "true" } else { "false" })
+    serializer.serialize_str(&value.to_string())
 }
 
 fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
@@ -214,11 +214,11 @@ where
     D: serde::Deserializer<'de>,
 {
     let value = <&str>::deserialize(deserializer)?;
-    match value.trim().to_lowercase().as_str() {
-        "true" => Ok(true),
-        "false" => Ok(false),
-        _ => Err(serde::de::Error::custom("expected 'true' or 'false'")),
-    }
+    value
+        .trim()
+        .to_lowercase()
+        .parse()
+        .map_err(serde::de::Error::custom)
 }
 
 #[cfg(test)]

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -7,17 +7,7 @@ pub struct EditableField<T> {
     /// A unique identifier for the [EditableField] which is machine generated and an opaque byte
     /// sequence with a maximum size of 64 bytes. It SHOULD NOT be displayed to the user.
     pub id: Option<B64Url>,
-    /// This member defines the meaning of the [value][EditableField::value] member and its type.
-    /// This meaning is two-fold:
-    ///
-    /// 1. The string representation of the value if its native type is not a string.
-    /// 2. The UI representation used to display the value.
-    ///
-    /// The value SHOULD be a member of [FieldType] and the
-    /// [importing provider](https://fidoalliance.org/specs/cx/cxp-v1.0-wd-20241003.html#importing-provider)
-    /// SHOULD ignore any unknown values and default to [string][FieldType::String].
-    /// pub field_type: FieldType,
-    /// This member contains the [fieldType][EditableField::field_type] defined by the user.
+    /// This member contains the fieldType defined by the user.
     pub value: T,
     /// This member contains a user facing value describing the value stored. This value MAY be
     /// user defined.
@@ -110,6 +100,7 @@ where
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
 pub struct EditableFieldString(String);
 impl EditableFieldType for EditableFieldString {
     fn field_type(&self) -> FieldType {
@@ -118,6 +109,7 @@ impl EditableFieldType for EditableFieldString {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
 pub struct EditableFieldConcealedString(String);
 impl EditableFieldType for EditableFieldConcealedString {
     fn field_type(&self) -> FieldType {
@@ -126,7 +118,6 @@ impl EditableFieldType for EditableFieldConcealedString {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-
 pub struct EditableFieldBoolean(
     #[serde(
         serialize_with = "serialize_bool",
@@ -141,6 +132,7 @@ impl EditableFieldType for EditableFieldBoolean {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
 pub struct EditableFieldDate(String);
 impl EditableFieldType for EditableFieldDate {
     fn field_type(&self) -> FieldType {
@@ -149,6 +141,7 @@ impl EditableFieldType for EditableFieldDate {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
 pub struct EditableFieldYearMonth(String);
 impl EditableFieldType for EditableFieldYearMonth {
     fn field_type(&self) -> FieldType {
@@ -157,6 +150,7 @@ impl EditableFieldType for EditableFieldYearMonth {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
 pub struct EditableFieldSubdivisionCode(String);
 impl EditableFieldType for EditableFieldSubdivisionCode {
     fn field_type(&self) -> FieldType {
@@ -165,6 +159,7 @@ impl EditableFieldType for EditableFieldSubdivisionCode {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
 pub struct EditableFieldCountryCode(String);
 impl EditableFieldType for EditableFieldCountryCode {
     fn field_type(&self) -> FieldType {

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -36,8 +36,8 @@ enum FieldType {
     SubdivisionCode,
     CountryCode,
 
-    #[serde(other)]
-    Unknown,
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 /// A trait to associate the field structs with their `field_type` tag.
@@ -63,7 +63,7 @@ where
             state.skip_field("id")?;
         }
 
-        state.serialize_field("field_type", &self.value.field_type())?;
+        state.serialize_field("fieldType", &self.value.field_type())?;
         state.serialize_field("value", &self.value)?;
 
         if let Some(ref label) = self.label {
@@ -85,6 +85,7 @@ where
         D: serde::Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
         struct EditableFieldHelper<T> {
             id: Option<B64Url>,
             value: T,
@@ -205,7 +206,7 @@ mod tests {
         };
         let json = json!({
             "value": "value",
-            "field_type": "string",
+            "fieldType": "string",
             "label": "label",
         });
         assert_eq!(serde_json::to_value(&field).unwrap(), json);
@@ -215,7 +216,7 @@ mod tests {
     fn test_deserialize_field_string() {
         let json = json!({
             "value": "value",
-            "field_type": "string",
+            "fieldType": "string",
             "label": "label",
         });
         let field: EditableField<EditableFieldString> = serde_json::from_value(json).unwrap();
@@ -238,7 +239,7 @@ mod tests {
             label: Some("label".to_string()),
         };
         let json = json!({
-            "field_type": "concealed-string",
+            "fieldType": "concealed-string",
             "value": "value",
             "label": "label",
         });
@@ -249,7 +250,7 @@ mod tests {
     fn test_deserialize_field_wrong_type() {
         let json = json!({
             "value": "value",
-            "field_type": "string",
+            "fieldType": "string",
             "label": "label",
         });
         let field: Result<EditableField<EditableFieldConcealedString>, _> =
@@ -262,7 +263,7 @@ mod tests {
     fn test_deserialize_field_bad_value_string() {
         let json = json!({
             "value": 5,
-            "field_type": "string",
+            "fieldType": "string",
             "label": "label",
         });
         let field: Result<EditableField<EditableFieldString>, _> = serde_json::from_value(json);
@@ -274,7 +275,7 @@ mod tests {
     fn test_deserialize_field_bad_value_bool() {
         let json = json!({
             "value": "bad",
-            "field_type": "bool",
+            "fieldType": "bool",
             "label": "label",
         });
         let field: Result<EditableField<EditableFieldBoolean>, _> = serde_json::from_value(json);
@@ -298,7 +299,7 @@ mod tests {
     fn test_deserialize_field_concealed_string() {
         let json = json!({
             "value": "value",
-            "field_type": "concealed-string",
+            "fieldType": "concealed-string",
             "label": "label",
         });
         let field: EditableField<EditableFieldConcealedString> =
@@ -322,7 +323,7 @@ mod tests {
             label: Some("label".to_string()),
         };
         let json = json!({
-            "field_type": "boolean",
+            "fieldType": "boolean",
             "value": "true",
             "label": "label",
         });

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -135,13 +135,7 @@ impl EditableFieldType for EditableFieldConcealedString {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct EditableFieldBoolean(
-    #[serde(
-        serialize_with = "serialize_bool",
-        deserialize_with = "deserialize_bool"
-    )]
-    pub bool,
-);
+pub struct EditableFieldBoolean(#[serde(with = "serde_bool")] pub bool);
 impl EditableFieldType for EditableFieldBoolean {
     fn field_type(&self) -> FieldType {
         FieldType::Boolean
@@ -202,23 +196,28 @@ impl EditableFieldType for EditableFieldWifiNetworkSecurityType {
     }
 }
 
-fn serialize_bool<S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(&value.to_string())
-}
+mod serde_bool {
+    use serde::Deserialize;
 
-fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <&str>::deserialize(deserializer)?;
-    value
-        .trim()
-        .to_lowercase()
-        .parse()
-        .map_err(serde::de::Error::custom)
+    pub fn serialize<S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&value.to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<bool, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <&str>::deserialize(deserializer)?;
+
+        value
+            .trim()
+            .to_lowercase()
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 #[cfg(test)]

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -259,6 +259,30 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_field_bad_value_string() {
+        let json = json!({
+            "value": 5,
+            "field_type": "string",
+            "label": "label",
+        });
+        let field: Result<EditableField<EditableFieldString>, _> = serde_json::from_value(json);
+
+        assert!(field.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_field_bad_value_bool() {
+        let json = json!({
+            "value": "bad",
+            "field_type": "bool",
+            "label": "label",
+        });
+        let field: Result<EditableField<EditableFieldBoolean>, _> = serde_json::from_value(json);
+
+        assert!(field.is_err());
+    }
+
+    #[test]
     fn test_deserialize_field_missing_type() {
         let json = json!({
             "value": "value",

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -14,18 +14,35 @@ pub struct EditableField<T> {
     pub label: Option<String>,
 }
 
-/// Internal enum to represent the different field types.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-enum FieldType {
+pub enum FieldType {
+    /// A UTF-8 encoded string value which is unconcealed and does not have a specified format.
     String,
+    /// A UTF-8 encoded string value which should be considered secret and not displayed unless the
+    /// user explicitly requests it.
     ConcealedString,
+    /// A UTF-8 encoded string value which follows the format specified in
+    /// [RFC5322](https://www.rfc-editor.org/rfc/rfc5322#section-3.4). This field SHOULD be
+    /// unconcealed.
+    Email,
+    /// A stringified numeric value which is unconcealed.
+    Number,
+    /// A boolean value which is unconcealed. It MUST be of the values "true" or "false".
     Boolean,
+    /// A string value representing a calendar date which follows the format specified in
+    /// [RFC3339](https://www.rfc-editor.org/rfc/rfc3339).
     Date,
+    /// A string value representing a calendar date which follows the date-fullyear "-" date-month
+    /// pattern as established in [RFC3339] Appendix A. This is equivalent to the YYYY-MM format
+    /// specified in [ISO-8601].
     YearMonth,
+    /// A string value representing a value that SHOULD be a member of WIFINetworkSecurityType.
+    WifiNetworkSecurityType,
+    /// A string value which MUST follow the ISO3166-1 alpha-2 format.
     SubdivisionCode,
+    /// A string which MUST follow the ISO3166-2 format.
     CountryCode,
-
     #[serde(untagged)]
     Unknown(String),
 }
@@ -164,6 +181,24 @@ pub struct EditableFieldCountryCode(String);
 impl EditableFieldType for EditableFieldCountryCode {
     fn field_type(&self) -> FieldType {
         FieldType::CountryCode
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum EditableFieldWifiNetworkSecurityType {
+    Unsecured,
+    WpaPersonal,
+    Wpa2Personal,
+    Wpa3Personal,
+    Wep,
+
+    #[serde(untagged)]
+    Other(String),
+}
+impl EditableFieldType for EditableFieldWifiNetworkSecurityType {
+    fn field_type(&self) -> FieldType {
+        FieldType::WifiNetworkSecurityType
     }
 }
 

--- a/credential-exchange-types/src/format/identity.rs
+++ b/credential-exchange-types/src/format/identity.rs
@@ -3,8 +3,8 @@
 use serde::{Deserialize, Serialize};
 
 use super::{
-    EditableField, EditableFieldConcealedString, EditableFieldCountryCode, EditableFieldString,
-    EditableFieldSubdivisionCode, EditableFieldYearMonth,
+    EditableField, EditableFieldConcealedString, EditableFieldCountryCode, EditableFieldDate,
+    EditableFieldString, EditableFieldSubdivisionCode, EditableFieldYearMonth,
 };
 
 /// An [AddressCredential] provides information for autofilling address forms.
@@ -64,13 +64,13 @@ pub struct DriversLicenseCredential {
     pub full_name: Option<EditableField<EditableFieldString>>,
     /// Day, month, and year on which the license holder was born.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub birth_date: Option<EditableField<EditableFieldString>>,
+    pub birth_date: Option<EditableField<EditableFieldDate>>,
     /// The date on which the license was issued.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issue_date: Option<EditableField<EditableFieldString>>,
+    pub issue_date: Option<EditableField<EditableFieldDate>>,
     /// The date on which the license expires.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expiry_date: Option<EditableField<EditableFieldString>>,
+    pub expiry_date: Option<EditableField<EditableFieldDate>>,
     /// The official body or government agency responsible for issuing the license.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub issuing_authority: Option<EditableField<EditableFieldString>>,
@@ -105,7 +105,7 @@ pub struct DriversLicenseCredential {
 pub struct IdentityDocumentCredential {
     /// The document’s issuing country. This MUST conform to the ISO 3166-1 alpha-2 format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issuing_country: Option<EditableField<EditableFieldString>>,
+    pub issuing_country: Option<EditableField<EditableFieldCountryCode>>,
     /// The document’s identifying number. This identifying number is tied to the issuance of the
     /// document and is expected to change upon its reissuance, even when the person’s information
     /// might remain the same.
@@ -125,7 +125,7 @@ pub struct IdentityDocumentCredential {
     pub full_name: Option<EditableField<EditableFieldString>>,
     /// The person’s date of birth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub birth_date: Option<EditableField<EditableFieldString>>,
+    pub birth_date: Option<EditableField<EditableFieldDate>>,
     /// The person’s place of birth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub birth_place: Option<EditableField<EditableFieldString>>,
@@ -134,10 +134,10 @@ pub struct IdentityDocumentCredential {
     pub sex: Option<EditableField<EditableFieldString>>,
     /// The date on which the document was issued.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issue_date: Option<EditableField<EditableFieldString>>,
+    pub issue_date: Option<EditableField<EditableFieldDate>>,
     /// The date on which the document expires.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expiry_date: Option<EditableField<EditableFieldString>>,
+    pub expiry_date: Option<EditableField<EditableFieldDate>>,
     /// The official body or government agency responsible for issuing the document.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub issuing_authority: Option<EditableField<EditableFieldString>>,
@@ -150,7 +150,7 @@ pub struct IdentityDocumentCredential {
 pub struct PassportCredential {
     /// The passport’s issuing country. This MUST conform to the ISO 3166-1 alpha-2 format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    issuing_country: Option<EditableField<EditableFieldString>>,
+    issuing_country: Option<EditableField<EditableFieldCountryCode>>,
     /// The passport’s document type. This MUST be a valid document code as defined in ICAO Doc
     /// 9303 Part 4.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -169,7 +169,7 @@ pub struct PassportCredential {
     full_name: Option<EditableField<EditableFieldString>>,
     /// The person’s date of birth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    birth_date: Option<EditableField<EditableFieldString>>,
+    birth_date: Option<EditableField<EditableFieldDate>>,
     /// The person’s place of birth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     birth_place: Option<EditableField<EditableFieldString>>,
@@ -178,10 +178,10 @@ pub struct PassportCredential {
     sex: Option<EditableField<EditableFieldString>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// The date on which the passport was issued.
-    issue_date: Option<EditableField<EditableFieldString>>,
+    issue_date: Option<EditableField<EditableFieldDate>>,
     /// The date on which the passport expires.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    expiry_date: Option<EditableField<EditableFieldString>>,
+    expiry_date: Option<EditableField<EditableFieldDate>>,
     /// The official body or government agency responsible for issuing the passport.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     issuing_authority: Option<EditableField<EditableFieldString>>,

--- a/credential-exchange-types/src/format/identity.rs
+++ b/credential-exchange-types/src/format/identity.rs
@@ -4,7 +4,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{EditableField, EditableFieldString};
+use super::{
+    EditableField, EditableFieldConcealedString, EditableFieldCountryCode, EditableFieldString,
+    EditableFieldSubdivisionCode, EditableFieldYearMonth,
+};
 
 /// A [PersonNameCredential] represents a person’s name as fields derived from Unicode Locale Data
 /// Markup Language Part 8: Person Names.
@@ -51,16 +54,20 @@ pub struct PersonNameCredential {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreditCardCredential {
-    pub number: String,
-    pub full_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub card_type: Option<String>,
+    pub number: Option<EditableField<EditableFieldConcealedString>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub verification_number: Option<String>,
+    pub full_name: Option<EditableField<EditableFieldString>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expiry_date: Option<String>,
+    pub card_type: Option<EditableField<EditableFieldString>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub valid_from: Option<String>,
+    pub verification_number: Option<EditableField<EditableFieldConcealedString>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pin: Option<EditableField<EditableFieldConcealedString>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expiry_date: Option<EditableField<EditableFieldYearMonth>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_from: Option<EditableField<EditableFieldYearMonth>>,
 }
 
 /// An [AddressCredential] provides information for autofilling address forms.
@@ -80,11 +87,11 @@ pub struct AddressCredential {
     pub city: Option<EditableField<EditableFieldString>>,
     /// The province, state, or territory for the address.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub territory: Option<EditableField<EditableFieldString>>,
+    pub territory: Option<EditableField<EditableFieldSubdivisionCode>>,
     /// The country for the address. This MUST conform to the
     /// [ISO 3166-1 alpha-2](https://www.iso.org/iso-3166-country-codes.html) format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub country: Option<EditableField<EditableFieldString>>,
+    pub country: Option<EditableField<EditableFieldCountryCode>>,
     /// The phone number associated with the address.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tel: Option<EditableField<EditableFieldString>>,
@@ -115,10 +122,10 @@ pub struct DriversLicenseCredential {
     /// administrative subdivisions are states or provinces. This MUST conform to the ISO 3166-2
     /// format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub territory: Option<EditableField<EditableFieldString>>,
+    pub territory: Option<EditableField<EditableFieldSubdivisionCode>>,
     /// The license’s country of origin. This MUST conform to the ISO 3166-1 alpha-2 format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub country: Option<EditableField<EditableFieldString>>,
+    pub country: Option<EditableField<EditableFieldCountryCode>>,
     /// The number assigned by the issuing authority.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license_number: Option<EditableField<EditableFieldString>>,

--- a/credential-exchange-types/src/format/identity.rs
+++ b/credential-exchange-types/src/format/identity.rs
@@ -4,9 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::format::EditableField;
-
-use super::EditableFieldString;
+use super::{EditableField, EditableFieldString};
 
 /// A [PersonNameCredential] represents a person’s name as fields derived from Unicode Locale Data
 /// Markup Language Part 8: Person Names.

--- a/credential-exchange-types/src/format/identity.rs
+++ b/credential-exchange-types/src/format/identity.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::format::EditableField;
 
+use super::EditableFieldString;
+
 /// A [PersonNameCredential] represents a person’s name as fields derived from Unicode Locale Data
 /// Markup Language Part 8: Person Names.
 ///
@@ -18,34 +20,34 @@ pub struct PersonNameCredential {
     /// This OPTIONAL field contains a title or honorific qualifier. For example, "Ms.", "Mr.", or
     /// "Dr".
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    title: Option<EditableField>,
+    title: Option<EditableField<EditableFieldString>>,
     /// This OPTIONAL field the person’s given name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    given: Option<EditableField>,
+    given: Option<EditableField<EditableFieldString>>,
     /// This OPTIONAL field contains a nickname or preferred name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    given_informal: Option<EditableField>,
+    given_informal: Option<EditableField<EditableFieldString>>,
     /// This OPTIONAL field contains additional names or middle names.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    given2: Option<EditableField>,
+    given2: Option<EditableField<EditableFieldString>>,
     /// This OPTIONAL field contains the prefix of the surname. For example, "van der" in "van der
     /// Poel" or "bint" in "bint Fadi".
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    surname_prefix: Option<EditableField>,
+    surname_prefix: Option<EditableField<EditableFieldString>>,
     /// This OPTIONAL field contains the person’s family name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    surname: Option<EditableField>,
+    surname: Option<EditableField<EditableFieldString>>,
     /// This OPTIONAL field contains the person’s secondary surname, which is used in some
     /// cultures.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    surname2: Option<EditableField>,
+    surname2: Option<EditableField<EditableFieldString>>,
     /// This OPTIONAL field contains a credential or accreditation qualifier. For example, "PhD" or
     /// "MBA".
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    credentials: Option<EditableField>,
+    credentials: Option<EditableField<EditableFieldString>>,
     /// This OPTIONAL field contains a generation qualifier. For example, "Jr." or "III".
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    generation: Option<EditableField>,
+    generation: Option<EditableField<EditableFieldString>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -71,23 +73,23 @@ pub struct AddressCredential {
     /// address formats. Implementers MUST support multi-line addresses for this field, where each
     /// line is separated by a `\n` line feed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub street_address: Option<EditableField>,
+    pub street_address: Option<EditableField<EditableFieldString>>,
     /// The ZIP or postal code for the address.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<EditableField>,
+    pub postal_code: Option<EditableField<EditableFieldString>>,
     /// The city for the address.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub city: Option<EditableField>,
+    pub city: Option<EditableField<EditableFieldString>>,
     /// The province, state, or territory for the address.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub territory: Option<EditableField>,
+    pub territory: Option<EditableField<EditableFieldString>>,
     /// The country for the address. This MUST conform to the
     /// [ISO 3166-1 alpha-2](https://www.iso.org/iso-3166-country-codes.html) format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub country: Option<EditableField>,
+    pub country: Option<EditableField<EditableFieldString>>,
     /// The phone number associated with the address.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tel: Option<EditableField>,
+    pub tel: Option<EditableField<EditableFieldString>>,
 }
 
 /// A [DriversLicenseCredential] contains information about a person’s driver’s license. The fields
@@ -98,32 +100,32 @@ pub struct AddressCredential {
 pub struct DriversLicenseCredential {
     /// The full name of the license holder.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub full_name: Option<EditableField>,
+    pub full_name: Option<EditableField<EditableFieldString>>,
     /// Day, month, and year on which the license holder was born.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub birth_date: Option<EditableField>,
+    pub birth_date: Option<EditableField<EditableFieldString>>,
     /// The date on which the license was issued.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issue_date: Option<EditableField>,
+    pub issue_date: Option<EditableField<EditableFieldString>>,
     /// The date on which the license expires.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expiry_date: Option<EditableField>,
+    pub expiry_date: Option<EditableField<EditableFieldString>>,
     /// The official body or government agency responsible for issuing the license.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issuing_authority: Option<EditableField>,
+    pub issuing_authority: Option<EditableField<EditableFieldString>>,
     /// The principal administrative subdivision of the license’s country of origin. Examples of
     /// administrative subdivisions are states or provinces. This MUST conform to the ISO 3166-2
     /// format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub territory: Option<EditableField>,
+    pub territory: Option<EditableField<EditableFieldString>>,
     /// The license’s country of origin. This MUST conform to the ISO 3166-1 alpha-2 format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub country: Option<EditableField>,
+    pub country: Option<EditableField<EditableFieldString>>,
     /// The number assigned by the issuing authority.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub license_number: Option<EditableField>,
+    pub license_number: Option<EditableField<EditableFieldString>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub license_class: Option<EditableField>,
+    pub license_class: Option<EditableField<EditableFieldString>>,
 }
 
 /// An [IdentityDocumentCredential] is for any document, card, or number identifying a person or
@@ -142,42 +144,42 @@ pub struct DriversLicenseCredential {
 pub struct IdentityDocumentCredential {
     /// The document’s issuing country. This MUST conform to the ISO 3166-1 alpha-2 format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issuing_country: Option<EditableField>,
+    pub issuing_country: Option<EditableField<EditableFieldString>>,
     /// The document’s identifying number. This identifying number is tied to the issuance of the
     /// document and is expected to change upon its reissuance, even when the person’s information
     /// might remain the same.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub document_number: Option<EditableField>,
+    pub document_number: Option<EditableField<EditableFieldString>>,
     /// The person’s or other entity’s identification number. This identifying number is generally
     /// expected to remain stable across reissuances of the identity document itself. For
     /// identification numbers that are not an identity document (e.g., SSN, TIN, or VAT), this
     /// field is generally the only one that’s expected to be present in the credential.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub identification_number: Option<EditableField>,
+    pub identification_number: Option<EditableField<EditableFieldString>>,
     /// The person’s nationality.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub nationality: Option<EditableField>,
+    pub nationality: Option<EditableField<EditableFieldString>>,
     /// The person’s full name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub full_name: Option<EditableField>,
+    pub full_name: Option<EditableField<EditableFieldString>>,
     /// The person’s date of birth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub birth_date: Option<EditableField>,
+    pub birth_date: Option<EditableField<EditableFieldString>>,
     /// The person’s place of birth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub birth_place: Option<EditableField>,
+    pub birth_place: Option<EditableField<EditableFieldString>>,
     /// The person’s sex or gender.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sex: Option<EditableField>,
+    pub sex: Option<EditableField<EditableFieldString>>,
     /// The date on which the document was issued.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issue_date: Option<EditableField>,
+    pub issue_date: Option<EditableField<EditableFieldString>>,
     /// The date on which the document expires.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expiry_date: Option<EditableField>,
+    pub expiry_date: Option<EditableField<EditableFieldString>>,
     /// The official body or government agency responsible for issuing the document.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issuing_authority: Option<EditableField>,
+    pub issuing_authority: Option<EditableField<EditableFieldString>>,
 }
 
 /// A [PassportCredential] contains the details of a person’s passport. The fields reflect the
@@ -187,39 +189,39 @@ pub struct IdentityDocumentCredential {
 pub struct PassportCredential {
     /// The passport’s issuing country. This MUST conform to the ISO 3166-1 alpha-2 format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    issuing_country: Option<EditableField>,
+    issuing_country: Option<EditableField<EditableFieldString>>,
     /// The passport’s document type. This MUST be a valid document code as defined in ICAO Doc
     /// 9303 Part 4.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    passport_type: Option<EditableField>,
+    passport_type: Option<EditableField<EditableFieldString>>,
     /// The passport’s identifying number.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    passport_number: Option<EditableField>,
+    passport_number: Option<EditableField<EditableFieldString>>,
     /// The person’s national identification number.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    national_identification_number: Option<EditableField>,
+    national_identification_number: Option<EditableField<EditableFieldString>>,
     /// The person’s nationality.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    nationality: Option<EditableField>,
+    nationality: Option<EditableField<EditableFieldString>>,
     /// The person’s full name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    full_name: Option<EditableField>,
+    full_name: Option<EditableField<EditableFieldString>>,
     /// The person’s date of birth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    birth_date: Option<EditableField>,
+    birth_date: Option<EditableField<EditableFieldString>>,
     /// The person’s place of birth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    birth_place: Option<EditableField>,
+    birth_place: Option<EditableField<EditableFieldString>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// The person’s sex or gender.
-    sex: Option<EditableField>,
+    sex: Option<EditableField<EditableFieldString>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// The date on which the passport was issued.
-    issue_date: Option<EditableField>,
+    issue_date: Option<EditableField<EditableFieldString>>,
     /// The date on which the passport expires.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    expiry_date: Option<EditableField>,
+    expiry_date: Option<EditableField<EditableFieldString>>,
     /// The official body or government agency responsible for issuing the passport.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    issuing_authority: Option<EditableField>,
+    issuing_authority: Option<EditableField<EditableFieldString>>,
 }

--- a/credential-exchange-types/src/format/login.rs
+++ b/credential-exchange-types/src/format/login.rs
@@ -10,6 +10,8 @@ use crate::{
     B64Url, Uri,
 };
 
+use super::EditableFieldString;
+
 /// A [BasicAuthCredential] contains a username/password login credential.
 /// Can either represent a [Basic access authentication](https://www.rfc-editor.org/rfc/rfc7617)
 /// or a form on a web page.
@@ -20,10 +22,10 @@ pub struct BasicAuthCredential {
     pub urls: Vec<Uri>,
     /// The username associated with the credential.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub username: Option<EditableField>,
+    pub username: Option<EditableField<EditableFieldString>>,
     /// The password associated with the credential.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub password: Option<EditableField>,
+    pub password: Option<EditableField<EditableFieldString>>,
 }
 
 /// Passkey
@@ -160,16 +162,16 @@ pub struct SshKeyCredential {
     /// This OPTIONAL member indicates when the key was created. When present, its internal
     /// fieldType SHOULD be of type date.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    creation_date: Option<EditableField>,
+    creation_date: Option<EditableField<EditableFieldString>>,
     /// This OPTIONAL member indicates when the key will expire, if applicable. When present, its
     /// internal fieldType SHOULD be of type date.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    expiration_date: Option<EditableField>,
+    expiration_date: Option<EditableField<EditableFieldString>>,
     /// This OPTIONAL member indicates where the key was originally generated. E.g.,
     /// `https://github.com/settings/ssh/new` for GitHub. When present, its internal fieldType
     /// SHOULD be of type string.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    key_generation_source: Option<EditableField>,
+    key_generation_source: Option<EditableField<EditableFieldString>>,
 }
 
 /// A [ApiKeyCredential] contains information to interact with an Application's Programming
@@ -179,32 +181,32 @@ pub struct SshKeyCredential {
 pub struct ApiKeyCredential {
     /// This REQUIRED member denotes the key to communicate with the API. Its internal fieldType
     /// SHOULD be of type ConcealedString.
-    key: EditableField,
+    key: EditableField<EditableFieldString>,
 
-    /// This OPTIONAL member denotes the username associated with the key and its internal fieldType
-    /// SHOULD be of type string
+    /// This OPTIONAL member denotes the username associated with the key and its internal
+    /// fieldType SHOULD be of type string
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    username: Option<EditableField>,
+    username: Option<EditableField<EditableFieldString>>,
 
     /// This OPTIONAL member denotes the type of the API key, such as bearer token or
-    /// JSON Web Token. It is flexible to allow any type and not restrict it to a set list of types.
-    /// Its internal fieldType SHOULD be of type string.
+    /// JSON Web Token. It is flexible to allow any type and not restrict it to a set list of
+    /// types. Its internal fieldType SHOULD be of type string.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    key_type: Option<EditableField>,
+    key_type: Option<EditableField<EditableFieldString>>,
 
     /// This OPTIONAL member denotes the url the API key is used with and SHOULD conform to the
     /// [URL Standard](https://url.spec.whatwg.org/). Its internal fieldType SHOULD be of type
     /// string.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    url: Option<EditableField>,
+    url: Option<EditableField<EditableFieldString>>,
 
     /// This OPTIONAL member denotes the date the API key is valid from and its internal fieldType
     /// SHOULD be of type date.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    valid_from: Option<EditableField>,
+    valid_from: Option<EditableField<EditableFieldString>>,
 
     /// This OPTIONAL member denotes the date on which the API key expires
     /// and its internal fieldType SHOULD be of type date.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    expiry_date: Option<EditableField>,
+    expiry_date: Option<EditableField<EditableFieldString>>,
 }

--- a/credential-exchange-types/src/format/login.rs
+++ b/credential-exchange-types/src/format/login.rs
@@ -4,13 +4,12 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::EditableFieldString;
 use crate::{
     b64url::B32,
     format::{EditableField, Fido2Extensions},
     B64Url, Uri,
 };
-
-use super::EditableFieldString;
 
 /// A [BasicAuthCredential] contains a username/password login credential.
 /// Can either represent a [Basic access authentication](https://www.rfc-editor.org/rfc/rfc7617)

--- a/credential-exchange-types/src/format/login.rs
+++ b/credential-exchange-types/src/format/login.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::EditableFieldString;
+use super::{EditableFieldConcealedString, EditableFieldDate, EditableFieldString};
 use crate::{
     b64url::B32,
     format::{EditableField, Fido2Extensions},
@@ -24,7 +24,7 @@ pub struct BasicAuthCredential {
     pub username: Option<EditableField<EditableFieldString>>,
     /// The password associated with the credential.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub password: Option<EditableField<EditableFieldString>>,
+    pub password: Option<EditableField<EditableFieldConcealedString>>,
 }
 
 /// Passkey
@@ -161,11 +161,11 @@ pub struct SshKeyCredential {
     /// This OPTIONAL member indicates when the key was created. When present, its internal
     /// fieldType SHOULD be of type date.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    creation_date: Option<EditableField<EditableFieldString>>,
+    creation_date: Option<EditableField<EditableFieldDate>>,
     /// This OPTIONAL member indicates when the key will expire, if applicable. When present, its
     /// internal fieldType SHOULD be of type date.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    expiration_date: Option<EditableField<EditableFieldString>>,
+    expiration_date: Option<EditableField<EditableFieldDate>>,
     /// This OPTIONAL member indicates where the key was originally generated. E.g.,
     /// `https://github.com/settings/ssh/new` for GitHub. When present, its internal fieldType
     /// SHOULD be of type string.
@@ -180,7 +180,7 @@ pub struct SshKeyCredential {
 pub struct ApiKeyCredential {
     /// This REQUIRED member denotes the key to communicate with the API. Its internal fieldType
     /// SHOULD be of type ConcealedString.
-    key: EditableField<EditableFieldString>,
+    key: EditableField<EditableFieldConcealedString>,
 
     /// This OPTIONAL member denotes the username associated with the key and its internal
     /// fieldType SHOULD be of type string
@@ -202,10 +202,10 @@ pub struct ApiKeyCredential {
     /// This OPTIONAL member denotes the date the API key is valid from and its internal fieldType
     /// SHOULD be of type date.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    valid_from: Option<EditableField<EditableFieldString>>,
+    valid_from: Option<EditableField<EditableFieldDate>>,
 
     /// This OPTIONAL member denotes the date on which the API key expires
     /// and its internal fieldType SHOULD be of type date.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    expiry_date: Option<EditableField<EditableFieldString>>,
+    expiry_date: Option<EditableField<EditableFieldDate>>,
 }


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates `EditableField` to be strongly typed to minimize confusion on the consuming side. A known limitation is that we currently only support a single type per field and if we ever have to support an enum this will need to be adjusted.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
