### PR TITLE
Propose impl from for editable fields

### DIFF
--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -304,12 +304,7 @@ impl EditableFieldType for EditableFieldSubdivisionCode {
 
 impl From<String> for EditableField<EditableFieldSubdivisionCode> {
     fn from(s: String) -> Self {
-        EditableField {
-            id: None,
-            value: EditableFieldSubdivisionCode(s),
-            label: None,
-            extensions: None,
-        }
+        EditableFieldSubdivisionCode(s).into()
     }
 }
 
@@ -330,12 +325,7 @@ impl EditableFieldType for EditableFieldCountryCode {
 
 impl From<String> for EditableField<EditableFieldCountryCode> {
     fn from(s: String) -> Self {
-        EditableField {
-            id: None,
-            value: EditableFieldCountryCode(s),
-            label: None,
-            extensions: None,
-        }
+        EditableFieldCountryCode(s).into()
     }
 }
 

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -132,12 +132,46 @@ impl EditableFieldType for EditableFieldString {
     }
 }
 
+impl From<String> for EditableField<EditableFieldString> {
+    fn from(s: String) -> Self {
+        EditableField {
+            id: None,
+            value: EditableFieldString(s),
+            label: None,
+            extensions: None,
+        }
+    }
+}
+
+impl From<EditableField<EditableFieldString>> for String {
+    fn from(s: EditableField<EditableFieldString>) -> Self {
+        s.value.0
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct EditableFieldConcealedString(pub String);
 impl EditableFieldType for EditableFieldConcealedString {
     fn field_type(&self) -> FieldType {
         FieldType::ConcealedString
+    }
+}
+
+impl From<String> for EditableField<EditableFieldConcealedString> {
+    fn from(s: String) -> Self {
+        EditableField {
+            id: None,
+            value: EditableFieldConcealedString(s),
+            label: None,
+            extensions: None,
+        }
+    }
+}
+
+impl From<EditableField<EditableFieldConcealedString>> for String {
+    fn from(s: EditableField<EditableFieldConcealedString>) -> Self {
+        s.value.0
     }
 }
 
@@ -164,6 +198,17 @@ pub struct EditableFieldYearMonth(pub String);
 impl EditableFieldType for EditableFieldYearMonth {
     fn field_type(&self) -> FieldType {
         FieldType::YearMonth
+    }
+}
+
+impl From<String> for EditableField<EditableFieldYearMonth> {
+    fn from(s: String) -> Self {
+        EditableField {
+            id: None,
+            value: EditableFieldYearMonth(s),
+            label: None,
+            extensions: None,
+        }
     }
 }
 

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -183,12 +183,46 @@ impl EditableFieldType for EditableFieldBoolean {
     }
 }
 
+impl From<bool> for EditableField<EditableFieldBoolean> {
+    fn from(b: bool) -> Self {
+        EditableField {
+            id: None,
+            value: EditableFieldBoolean(b),
+            label: None,
+            extensions: None,
+        }
+    }
+}
+
+impl From<EditableField<EditableFieldBoolean>> for bool {
+    fn from(b: EditableField<EditableFieldBoolean>) -> Self {
+        b.value.0
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct EditableFieldDate(pub String);
 impl EditableFieldType for EditableFieldDate {
     fn field_type(&self) -> FieldType {
         FieldType::Date
+    }
+}
+
+impl From<String> for EditableField<EditableFieldDate> {
+    fn from(s: String) -> Self {
+        EditableField {
+            id: None,
+            value: EditableFieldDate(s),
+            label: None,
+            extensions: None,
+        }
+    }
+}
+
+impl From<EditableField<EditableFieldDate>> for String {
+    fn from(s: EditableField<EditableFieldDate>) -> Self {
+        s.value.0
     }
 }
 
@@ -212,6 +246,12 @@ impl From<String> for EditableField<EditableFieldYearMonth> {
     }
 }
 
+impl From<EditableField<EditableFieldYearMonth>> for String {
+    fn from(s: EditableField<EditableFieldYearMonth>) -> Self {
+        s.value.0
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct EditableFieldSubdivisionCode(pub String);
@@ -221,12 +261,46 @@ impl EditableFieldType for EditableFieldSubdivisionCode {
     }
 }
 
+impl From<String> for EditableField<EditableFieldSubdivisionCode> {
+    fn from(s: String) -> Self {
+        EditableField {
+            id: None,
+            value: EditableFieldSubdivisionCode(s),
+            label: None,
+            extensions: None,
+        }
+    }
+}
+
+impl From<EditableField<EditableFieldSubdivisionCode>> for String {
+    fn from(s: EditableField<EditableFieldSubdivisionCode>) -> Self {
+        s.value.0
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct EditableFieldCountryCode(pub String);
 impl EditableFieldType for EditableFieldCountryCode {
     fn field_type(&self) -> FieldType {
         FieldType::CountryCode
+    }
+}
+
+impl From<String> for EditableField<EditableFieldCountryCode> {
+    fn from(s: String) -> Self {
+        EditableField {
+            id: None,
+            value: EditableFieldCountryCode(s),
+            label: None,
+            extensions: None,
+        }
+    }
+}
+
+impl From<EditableField<EditableFieldCountryCode>> for String {
+    fn from(s: EditableField<EditableFieldCountryCode>) -> Self {
+        s.value.0
     }
 }
 


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

It would be nice to implement `From<Inner> for EditableField<EditableFieldInner>` as a shortcut when you don't have any metadata to add to the editable field.

This drastically simplifies our internal usage and I expect we're not the only provider which do not track ID or offer the label for many fields.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
