### PR TITLE
Revert "Enabled SonarQube scanning for PRs"

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -74,4 +74,3 @@ jobs:
           args: >
             -Dsonar.organization=${{ github.repository_owner }}
             -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
-            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}


### PR DESCRIPTION
Reverts bitwarden/credential-exchange#47

Disables the sonar qube PR scans since there is no rust support