### PR TITLE
Refine EditableField Date and YearMonth

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -3,6 +3,7 @@
   "version": "0.2",
   "words": [
     "Bitwarden",
+    "chrono",
     "Totp"
   ],
   "flagWords": [],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,32 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "credential-exchange-types"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "data-encoding",
  "jose-jwk",
  "serde",
@@ -68,6 +85,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/credential-exchange-types/Cargo.toml
+++ b/credential-exchange-types/Cargo.toml
@@ -10,11 +10,11 @@ license-file.workspace = true
 keywords.workspace = true
 
 [dependencies]
-data-encoding = "2"
-jose-jwk = { version = "0.1", default-features = false }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 chrono = { version = "0.4", features = [
     "serde",
     "std",
 ], default-features = false }
+data-encoding = "2"
+jose-jwk = { version = "0.1", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/credential-exchange-types/Cargo.toml
+++ b/credential-exchange-types/Cargo.toml
@@ -14,3 +14,7 @@ data-encoding = "2"
 jose-jwk = { version = "0.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+chrono = { version = ">=0.4.26, <0.5", features = [
+    "serde",
+    "std",
+], default-features = false }

--- a/credential-exchange-types/Cargo.toml
+++ b/credential-exchange-types/Cargo.toml
@@ -14,7 +14,7 @@ data-encoding = "2"
 jose-jwk = { version = "0.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-chrono = { version = ">=0.4.26, <0.5", features = [
+chrono = { version = "0.4", features = [
     "serde",
     "std",
 ], default-features = false }

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -1,4 +1,4 @@
-use chrono::DateTime;
+use chrono::NaiveDate;
 use serde::{de::DeserializeOwned, ser::SerializeStruct, Deserialize, Serialize};
 
 use crate::{format::Extension, B64Url};
@@ -152,7 +152,7 @@ impl EditableFieldType for EditableFieldBoolean {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct EditableFieldDate(pub DateTime<chrono::Utc>);
+pub struct EditableFieldDate(pub NaiveDate);
 impl EditableFieldType for EditableFieldDate {
     fn field_type(&self) -> FieldType {
         FieldType::Date
@@ -404,13 +404,13 @@ mod tests {
     fn test_serialize_field_date() {
         let field: EditableField<EditableFieldDate> = EditableField {
             id: None,
-            value: EditableFieldDate("2025-02-24T12:34:32Z".parse().unwrap()),
+            value: EditableFieldDate(NaiveDate::from_ymd_opt(2024, 2, 24).unwrap()),
             label: None,
             extensions: None,
         };
         let json = json!({
             "fieldType": "date",
-            "value": "2025-02-24T12:34:32Z",
+            "value": "2025-02-24",
         });
         assert_eq!(serde_json::to_value(&field).unwrap(), json);
     }

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -404,7 +404,7 @@ mod tests {
     fn test_serialize_field_date() {
         let field: EditableField<EditableFieldDate> = EditableField {
             id: None,
-            value: EditableFieldDate(NaiveDate::from_ymd_opt(2024, 2, 24).unwrap()),
+            value: EditableFieldDate(NaiveDate::from_ymd_opt(2025, 2, 24).unwrap()),
             label: None,
             extensions: None,
         };

--- a/credential-exchange-types/src/format/editable_field.rs
+++ b/credential-exchange-types/src/format/editable_field.rs
@@ -196,16 +196,15 @@ impl<'de> Deserialize<'de> for EditableFieldYearMonth {
         D: serde::Deserializer<'de>,
     {
         let s = deserializer.deserialize_str(CowVisitor)?;
-        let mut parts = s.splitn(2, '-');
+        let (year_str, month_str) = s
+            .split_once('-')
+            .ok_or_else(|| serde::de::Error::custom("Invalid format"))?;
+
         Ok(EditableFieldYearMonth {
-            year: parts
-                .next()
-                .unwrap_or("")
+            year: year_str
                 .parse::<u16>()
-                .map_err(|_| serde::de::Error::custom("Missing year"))?,
-            month: parts
-                .next()
-                .unwrap_or("")
+                .map_err(|_| serde::de::Error::custom("Invalid year"))?,
+            month: month_str
                 .parse::<u8>()
                 .map_err(|_| serde::de::Error::custom("Invalid month"))?
                 .try_into()


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

- Define `EditableFieldDate` as a new type around `chrono::NaiveDate`
- Define `EditableFieldYearMonth` as a struct containing two numbers.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
