### PR TITLE
Make API Key credential key field optional

### DIFF
--- a/credential-exchange-types/src/format/login.rs
+++ b/credential-exchange-types/src/format/login.rs
@@ -15,6 +15,7 @@ use crate::{
 #[serde(rename_all = "camelCase", bound(deserialize = "E: Deserialize<'de>"))]
 pub struct ApiKeyCredential<E = ()> {
     /// This member denotes the key to communicate with the API.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<EditableField<EditableFieldConcealedString, E>>,
     /// This member denotes the username associated with the key.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/credential-exchange-types/src/format/login.rs
+++ b/credential-exchange-types/src/format/login.rs
@@ -6,7 +6,7 @@ use super::{EditableFieldBoolean, EditableFieldWifiNetworkSecurityType};
 use crate::{
     b64url::B32,
     format::{EditableField, EditableFieldConcealedString, EditableFieldDate, EditableFieldString},
-    B64Url, Uri,
+    B64Url,
 };
 
 /// A [ApiKeyCredential] contains information to interact with an Application's Programming
@@ -15,7 +15,7 @@ use crate::{
 #[serde(rename_all = "camelCase", bound(deserialize = "E: Deserialize<'de>"))]
 pub struct ApiKeyCredential<E = ()> {
     /// This member denotes the key to communicate with the API.
-    pub key: EditableField<EditableFieldConcealedString, E>,
+    pub key: Option<EditableField<EditableFieldConcealedString, E>>,
     /// This member denotes the username associated with the key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username: Option<EditableField<EditableFieldString, E>>,


### PR DESCRIPTION
## 📔 Objective

Make API Key credential key field optional

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
