### PR TITLE
Switch to license rather than license-file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ edition = "2021"
 rust-version = "1.75"
 homepage = "https://bitwarden.com"
 repository = "https://github.com/bitwarden/credential-exchange"
-license-file = "LICENSE"
+license = "MIT"
 keywords = ["credential-exchange", "encoding"]

--- a/credential-exchange-format/Cargo.toml
+++ b/credential-exchange-format/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license.workspace = true
 keywords.workspace = true
 
 [dependencies]

--- a/credential-exchange-protocol/Cargo.toml
+++ b/credential-exchange-protocol/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license.workspace = true
 keywords.workspace = true
 
 [dependencies]

--- a/credential-exchange/Cargo.toml
+++ b/credential-exchange/Cargo.toml
@@ -8,5 +8,5 @@ edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

License shows up as non-standard in crates.io due to us using license-file instead of license. This changes to use license which should accurately show MIT on crates.io.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
