### PR TITLE
[PM-23766] Add the Shared defined extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,11 +26,11 @@ dependencies = [
 
 [[package]]
 name = "credential-exchange"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "credential-exchange-format"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "data-encoding",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "credential-exchange-protocol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "credential-exchange-format",
  "jose-jwk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 resolver = "2"
 members = [
-    "credential-exchange-format",
-    "credential-exchange-protocol",
-    "credential-exchange",
+  "credential-exchange-format",
+  "credential-exchange-protocol",
+  "credential-exchange",
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Bitwarden Inc"]
 edition = "2021"
 # Note: Changing rust-version should be considered a breaking change

--- a/credential-exchange-format/src/credential_scope.rs
+++ b/credential-exchange-format/src/credential_scope.rs
@@ -50,6 +50,7 @@ pub struct AndroidAppCertificateFingerprint {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum AndroidAppHashAlgorithm {
     Sha256,
     Sha1,

--- a/credential-exchange-format/src/editable_field.rs
+++ b/credential-exchange-format/src/editable_field.rs
@@ -27,6 +27,7 @@ pub struct EditableField<T, E = ()> {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum FieldType {
     /// A UTF-8 encoded string value which is unconcealed and does not have a specified format.
     String,
@@ -337,6 +338,7 @@ impl From<EditableField<EditableFieldCountryCode>> for String {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum EditableFieldWifiNetworkSecurityType {
     Unsecured,
     WpaPersonal,

--- a/credential-exchange-format/src/extensions.rs
+++ b/credential-exchange-format/src/extensions.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+/// An [Extension] is a generic object that can be used to extend the [Item] or [Account] with
+/// additional information.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "name", rename_all = "kebab-case")]
+pub enum Extension<E = ()> {
+    #[serde(untagged)]
+    /// External extensions defined by the implementor of this crate.
+    External(E),
+    /// Unknown extension
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
+}

--- a/credential-exchange-format/src/extensions.rs
+++ b/credential-exchange-format/src/extensions.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[cfg(doc)]
-use crate::{Account, Collection};
+use crate::{Account, Collection, Item};
 
 mod shared;
 

--- a/credential-exchange-format/src/extensions.rs
+++ b/credential-exchange-format/src/extensions.rs
@@ -1,10 +1,20 @@
 use serde::{Deserialize, Serialize};
 
+#[cfg(doc)]
+use crate::{Account, Collection};
+
+mod shared;
+
+pub use self::shared::*;
+
 /// An [Extension] is a generic object that can be used to extend the [Item] or [Account] with
 /// additional information.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "name", rename_all = "kebab-case")]
 pub enum Extension<E = ()> {
+    /// Defines a sharing relationship of [`Collection`] or [`Item`] between different user
+    /// accounts or groups.
+    Shared(SharedExtension),
     #[serde(untagged)]
     /// External extensions defined by the implementor of this crate.
     External(E),

--- a/credential-exchange-format/src/extensions.rs
+++ b/credential-exchange-format/src/extensions.rs
@@ -11,6 +11,7 @@ pub use self::shared::*;
 /// additional information.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "name", rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum Extension<E = ()> {
     /// Defines a sharing relationship of [`Collection`] or [`Item`] between different user
     /// accounts or groups.

--- a/credential-exchange-format/src/extensions/shared.rs
+++ b/credential-exchange-format/src/extensions/shared.rs
@@ -1,0 +1,95 @@
+use serde::{Deserialize, Serialize};
+
+use crate::B64Url;
+#[cfg(doc)]
+use crate::{Account, Collection, Item};
+
+/// Defines entity sharing between user accounts
+///
+/// Entities are shared by applying the [`Shared`] extension to them.
+/// This extensions MUST only be applied to [`Collections`] and [`Items`].
+///
+/// Entities that are shared MUST only be included in the exports for accounts that are credential
+/// owners or admins of the entity.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct SharedExtension {
+    /// A list of [`SharingAccessor`] objects that represents users or groups
+    /// and their permissions with respect to access on the entity to which the [`Shared`]
+    /// extension is applied.
+    pub accessors: Vec<SharingAccessor>,
+}
+
+/// A SharingAccessor represents a user or group and their access permissions with respect to an
+/// entity.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SharingAccessor {
+    /// Indicates the type of accessor for which permissions are defined.
+    /// Importers must ignore any SharingAccessor entries when this value is
+    /// [`SharingAccessorType::Unknown`].
+    #[serde(rename = "type")]
+    pub ty: SharingAccessorType,
+    /// This member specifies the [`Account`], identified by its [`Account::id`],
+    /// that has been given access to the shared entity by the current exporting Account.
+    pub account_id: B64Url,
+    /// This contains the accessor’s account name.
+    /// If [`Self::ty`] has the value [`SharingAccessorType::User`] this SHOULD be set to the
+    /// [`Account::username`]. If [`Self::ty`] has the value [`SharingAccessorType::Group`]
+    /// this SHOULD be set to the group’s name.
+    pub name: String,
+    /// The list of permissions that [`Account`] defined by [`Self::account_id`] has with respect
+    /// to access on the shared entity. Importers MUST ignore entries with value of
+    /// [`SharingAccessorPermission::Unknown`]. Importers MUST ignore any [`SharingAccessors=]
+    /// that have an empty permissions list, whether it’s been exported as empty or when it’s
+    /// empty as a result of ignoring all unknown entries.
+    pub permissions: Vec<SharingAccessorPermission>,
+}
+
+/// A SharingAccessorType indicates the type of accessor for which a [`SharingAccessor`] defines
+/// access permissions to the respective entity.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SharingAccessorType {
+    /// Indicates the respective [`SharingAccessor`] is describing a specific user’s [`Account`]'s
+    /// permissions on the shared entity.
+    User,
+    /// Indicates the respective [`SharingAccessor`] is describing a group of user’s permissions on
+    /// the shared entity.
+    Group,
+    /// An unknown [`SharingAccessorType`], this is meant for future compatibility.
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+/// The SharingAccessorPermission encodes the level of access the accessing [`Account`] is given to
+/// the respective entity.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SharingAccessorPermission {
+    /// Indicates that the respective [`SharingAccessor`] has read permissions on the associated
+    /// entity, excluding its secrets. This generally means that the client prevents the user
+    /// from revealing the secret (e.g., a password) in its interface. However, the user is
+    /// often still allowed to use the secrets in an autofill context.
+    Read,
+    /// Indicates that the respective [`SharingAccessor`] has read permissions on the associated
+    /// entity, including its secrets.
+    ReadSecret,
+    /// Indicates that the respective [`SharingAccessor`] has update permissions on the associated
+    /// entity.
+    Update,
+    /// Indicates that the respective [`SharingAccessor`] has the permission to create sub-entities
+    /// for the associated entity, if applicable.
+    Create,
+    /// Indicates that the respective [`SharingAccessor`] has the permission to delete any of the
+    /// associated entity’s sub-entities, if applicable.
+    Delete,
+    /// Indicates that the respective [`SharingAccessor`] can share any of the associated entity’s
+    /// sub-entities with users or groups, if applicable.
+    Share,
+    /// Indicates that the respective [`SharingAccessor`] can manage the associated entity,
+    /// meaning they can edit the entity’s attributes, share it with others, etc.
+    Manage,
+    /// An unknown permission, this is meant for future compatibility.
+    #[serde(untagged)]
+    Unknown(String),
+}

--- a/credential-exchange-format/src/extensions/shared.rs
+++ b/credential-exchange-format/src/extensions/shared.rs
@@ -49,6 +49,7 @@ pub struct SharingAccessor {
 /// access permissions to the respective entity.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum SharingAccessorType {
     /// Indicates the respective [`SharingAccessor`] is describing a specific user’s [`Account`]'s
     /// permissions on the shared entity.
@@ -65,6 +66,7 @@ pub enum SharingAccessorType {
 /// the respective entity.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum SharingAccessorPermission {
     /// Indicates that the respective [`SharingAccessor`] has read permissions on the associated
     /// entity, excluding its secrets. This generally means that the client prevents the user

--- a/credential-exchange-format/src/extensions/shared.rs
+++ b/credential-exchange-format/src/extensions/shared.rs
@@ -6,16 +6,16 @@ use crate::{Account, Collection, Item};
 
 /// Defines entity sharing between user accounts
 ///
-/// Entities are shared by applying the [`Shared`] extension to them.
-/// This extensions MUST only be applied to [`Collections`] and [`Items`].
+/// Entities are shared by applying the [`SharedExtension`] extension to them.
+/// This extensions MUST only be applied to [`Collection`] and [`Item`].
 ///
 /// Entities that are shared MUST only be included in the exports for accounts that are credential
 /// owners or admins of the entity.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct SharedExtension {
     /// A list of [`SharingAccessor`] objects that represents users or groups
-    /// and their permissions with respect to access on the entity to which the [`Shared`]
-    /// extension is applied.
+    /// and their permissions with respect to access on the entity to which the [`SharedExtension`]
+    /// is applied.
     pub accessors: Vec<SharingAccessor>,
 }
 

--- a/credential-exchange-format/src/lib.rs
+++ b/credential-exchange-format/src/lib.rs
@@ -6,13 +6,14 @@ mod b64url;
 mod credential_scope;
 mod document;
 mod editable_field;
+mod extensions;
 mod identity;
 mod login;
 mod passkey;
 
 pub use self::{
-    b64url::*, credential_scope::*, document::*, editable_field::*, identity::*, login::*,
-    passkey::*,
+    b64url::*, credential_scope::*, document::*, editable_field::*, extensions::*, identity::*,
+    login::*, passkey::*,
 };
 
 type Uri = String;
@@ -156,19 +157,6 @@ pub struct Item<E = ()> {
     /// that is being exported to be as complete of an export as possible.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extensions: Option<Vec<Extension<E>>>,
-}
-
-/// An [Extension] is a generic object that can be used to extend the [Item] or [Account] with
-/// additional information.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "name", rename_all = "kebab-case")]
-pub enum Extension<E = ()> {
-    #[serde(untagged)]
-    /// External extensions defined by the implementor of this crate.
-    External(E),
-    /// Unknown extension
-    #[serde(untagged)]
-    Unknown(serde_json::Value),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/credential-exchange-format/src/lib.rs
+++ b/credential-exchange-format/src/lib.rs
@@ -165,6 +165,7 @@ pub struct Item<E = ()> {
     rename_all = "kebab-case",
     bound(deserialize = "E: Deserialize<'de>")
 )]
+#[non_exhaustive]
 pub enum Credential<E = ()> {
     Address(Box<AddressCredential<E>>),
     ApiKey(Box<ApiKeyCredential<E>>),

--- a/credential-exchange-format/src/login.rs
+++ b/credential-exchange-format/src/login.rs
@@ -131,6 +131,7 @@ pub struct TotpCredential {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum OTPHashAlgorithm {
     /// This algorithm denotes that [SHA1](https://www.rfc-editor.org/rfc/rfc3174) MUST be used to
     /// generate the OTP hash.

--- a/credential-exchange-protocol/Cargo.toml
+++ b/credential-exchange-protocol/Cargo.toml
@@ -12,6 +12,6 @@ license.workspace = true
 keywords.workspace = true
 
 [dependencies]
-credential-exchange-format = { path = "../credential-exchange-format", version = "0.1" }
+credential-exchange-format = { path = "../credential-exchange-format", version = "0.2" }
 jose-jwk = { version = "0.1", default-features = false }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
We noticed that the crate didn't include the defined extension [`Shared`](https://fidoalliance.org/specs/cx/cxf-v1.0-rd-20250313.html#sctn-sharing-an-entity). This adds the extension to the `Extension` object as it is a known extension and should be available even with External extensions defined.

I also noticed that by adding the `Extension::Shared` variant, we introduce a breaking change since `Extension` is exhaustive. So I went around and made every enum in the crate to be `#[non_exhaustive]`. This makes it so that purely additive changes to those enums are not breaking changes to the library, similar to how we set them up in the spec.
