### PR TITLE
[PM-33496] Loosen parsing rules by introducing a new `Expected` value type

### DIFF
--- a/credential-exchange-format/CHANGELOG.md
+++ b/credential-exchange-format/CHANGELOG.md
@@ -20,6 +20,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **BREAKING**: Changed `integration_hash` to `integrity_hash` in `FileCredential`. (#87)
 - **BREAKING**: Renamed `ty` to `type` in serialized representations of `Credential::Unknown`.
   (#125)
+- **BREAKING**: Field values are now using a new type to encode whether the field was parsed as the
+  expected field type, or whether the field was of the wrong type. (#127)
 
 ### Fixed
 

--- a/credential-exchange-format/src/document.rs
+++ b/credential-exchange-format/src/document.rs
@@ -65,13 +65,13 @@ mod tests {
             fields: vec![
                 EditableFieldValue::<()>::String(EditableField {
                     id: Some(B64Url::from(b"field1".as_slice())),
-                    value: EditableFieldString("hello".into()),
+                    value: EditableFieldString("hello".into()).into(),
                     label: None,
                     extensions: None,
                 }),
                 EditableFieldValue::<()>::Boolean(EditableField {
                     id: None,
-                    value: EditableFieldBoolean(false),
+                    value: EditableFieldBoolean(false).into(),
                     label: None,
                     extensions: None,
                 }),
@@ -129,21 +129,21 @@ mod tests {
 
         match &credential.fields[0] {
             EditableFieldValue::String(field) => {
-                assert_eq!(field.value.0, "hello");
+                assert_eq!(field.value.as_expected().map(|v| v.0.as_str()), Ok("hello"));
             }
             _ => panic!("Expected string field"),
         }
 
         match &credential.fields[1] {
             EditableFieldValue::ConcealedString(field) => {
-                assert_eq!(field.value.0, "world");
+                assert_eq!(field.value.as_expected().map(|v| v.0.as_str()), Ok("world"));
             }
             _ => panic!("Expected concealed string field"),
         }
 
         match &credential.fields[2] {
             EditableFieldValue::Boolean(field) => {
-                assert!(!field.value.0);
+                assert_eq!(field.value.as_expected().map(|e| e.0), Ok(false));
             }
             _ => panic!("Expected boolean field"),
         }
@@ -151,11 +151,11 @@ mod tests {
         match &credential.fields[3] {
             EditableFieldValue::YearMonth(field) => {
                 assert_eq!(
-                    field.value,
-                    EditableFieldYearMonth {
+                    field.value.as_expected(),
+                    Ok(&EditableFieldYearMonth {
                         year: 2025,
                         month: Month::February,
-                    }
+                    })
                 );
             }
             _ => panic!("Expected boolean field"),

--- a/credential-exchange-format/src/editable_field.rs
+++ b/credential-exchange-format/src/editable_field.rs
@@ -87,7 +87,7 @@ impl From<UnexpectedField> for String {
             UnexpectedField::Unknown { value: v, .. } => v,
             UnexpectedField::Email(v) => v.0,
             UnexpectedField::Number(v) => v.0,
-            UnexpectedField::Boolean(b) => if b.0 { "true" } else { "false" }.into(),
+            UnexpectedField::Boolean(v) => v.into(),
             UnexpectedField::Date(date) => date.0.format("%Y-%m-%d").to_string(),
             UnexpectedField::YearMonth(v) => v.into(),
         }
@@ -438,6 +438,13 @@ impl EditableFieldType for EditableFieldBoolean {
 impl<E> From<bool> for EditableField<EditableFieldBoolean, E> {
     fn from(b: bool) -> Self {
         EditableFieldBoolean(b).into()
+    }
+}
+
+impl From<EditableFieldBoolean> for String {
+    #[inline]
+    fn from(value: EditableFieldBoolean) -> Self {
+        if value.0 { "true" } else { "false" }.into()
     }
 }
 

--- a/credential-exchange-format/src/editable_field.rs
+++ b/credential-exchange-format/src/editable_field.rs
@@ -81,14 +81,7 @@ impl From<UnexpectedField> for String {
         match value {
             UnexpectedField::String(v) => v.0,
             UnexpectedField::ConcealedString(v) => v.0,
-            UnexpectedField::WifiNetworkSecurityType(v) => match v {
-                EditableFieldWifiNetworkSecurityType::Unsecured => "unsecured".into(),
-                EditableFieldWifiNetworkSecurityType::WpaPersonal => "wpa-personal".into(),
-                EditableFieldWifiNetworkSecurityType::Wpa2Personal => "wpa2-personal".into(),
-                EditableFieldWifiNetworkSecurityType::Wpa3Personal => "wpa3-personal".into(),
-                EditableFieldWifiNetworkSecurityType::Wep => "wep".into(),
-                EditableFieldWifiNetworkSecurityType::Other(o) => o,
-            },
+            UnexpectedField::WifiNetworkSecurityType(v) => v.into(),
             UnexpectedField::SubdivisionCode(v) => v.0,
             UnexpectedField::CountryCode(v) => v.0,
             UnexpectedField::Unknown { value: v, .. } => v,
@@ -549,6 +542,20 @@ pub enum EditableFieldWifiNetworkSecurityType {
 impl EditableFieldType for EditableFieldWifiNetworkSecurityType {
     fn field_type() -> FieldType {
         FieldType::WifiNetworkSecurityType
+    }
+}
+
+impl From<EditableFieldWifiNetworkSecurityType> for String {
+    #[inline]
+    fn from(value: EditableFieldWifiNetworkSecurityType) -> Self {
+        match value {
+            EditableFieldWifiNetworkSecurityType::Unsecured => "unsecured".into(),
+            EditableFieldWifiNetworkSecurityType::WpaPersonal => "wpa-personal".into(),
+            EditableFieldWifiNetworkSecurityType::Wpa2Personal => "wpa2-personal".into(),
+            EditableFieldWifiNetworkSecurityType::Wpa3Personal => "wpa3-personal".into(),
+            EditableFieldWifiNetworkSecurityType::Wep => "wep".into(),
+            EditableFieldWifiNetworkSecurityType::Other(o) => o,
+        }
     }
 }
 

--- a/credential-exchange-format/src/editable_field.rs
+++ b/credential-exchange-format/src/editable_field.rs
@@ -410,6 +410,13 @@ macro_rules! editable_field_string_type {
             }
         }
 
+        impl From<$name> for String {
+            #[inline]
+            fn from(v: $name) -> Self {
+                v.0
+            }
+        }
+
         impl AsRef<str> for $name {
             #[inline]
             fn as_ref(&self) -> &str {

--- a/credential-exchange-format/src/editable_field.rs
+++ b/credential-exchange-format/src/editable_field.rs
@@ -2,7 +2,10 @@ use std::{borrow::Cow, fmt, str};
 
 use chrono::{Month, NaiveDate};
 use serde::{
-    de::{DeserializeOwned, Visitor},
+    de::{
+        value::{StrDeserializer, StringDeserializer},
+        DeserializeOwned, Visitor,
+    },
     ser::SerializeStruct,
     Deserialize, Serialize,
 };
@@ -15,7 +18,7 @@ pub struct EditableField<T, E = ()> {
     /// sequence with a maximum size of 64 bytes. It SHOULD NOT be displayed to the user.
     pub id: Option<B64Url>,
     /// This member contains the fieldType defined by the user.
-    pub value: T,
+    pub value: Expected<T>,
     /// This member contains a user facing value describing the value stored. This value MAY be
     /// user defined.
     pub label: Option<String>,
@@ -23,6 +26,144 @@ pub struct EditableField<T, E = ()> {
     /// [EditableField]. This MAY be used to provide an exchange where a minimal amount of
     /// information is lost.
     pub extensions: Option<Vec<Extension<E>>>,
+}
+
+/// A field of the incorrect type that was passed instead of an expected field type.
+///
+/// For example if the spec requires a `string` type, but the user passes in
+/// `concealed-string` instead.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum UnexpectedField {
+    String(EditableFieldString),
+    ConcealedString(EditableFieldConcealedString),
+    Boolean(EditableFieldBoolean),
+    Date(EditableFieldDate),
+    YearMonth(EditableFieldYearMonth),
+    SubdivisionCode(EditableFieldSubdivisionCode),
+    CountryCode(EditableFieldCountryCode),
+    WifiNetworkSecurityType(EditableFieldWifiNetworkSecurityType),
+    Unknown {
+        /// The unexpected field type.
+        field_type: FieldType,
+        /// The Unknown string passed as a value of type `field_type`.
+        ///
+        /// Example: a `date` that doesn't conform to `yyyy-mm-dd`.
+        value: String,
+    },
+}
+
+impl UnexpectedField {
+    /// Returns the [`FieldType`] for this value.
+    #[inline]
+    pub fn field_type(&self) -> FieldType {
+        match self {
+            Self::String(_) => EditableFieldString::field_type(),
+            Self::ConcealedString(_) => EditableFieldConcealedString::field_type(),
+            Self::Boolean(_) => EditableFieldBoolean::field_type(),
+            Self::Date(_) => EditableFieldDate::field_type(),
+            Self::YearMonth(_) => EditableFieldYearMonth::field_type(),
+            Self::SubdivisionCode(_) => EditableFieldSubdivisionCode::field_type(),
+            Self::CountryCode(_) => EditableFieldCountryCode::field_type(),
+            Self::WifiNetworkSecurityType(_) => EditableFieldWifiNetworkSecurityType::field_type(),
+            Self::Unknown { field_type, .. } => field_type.clone(),
+        }
+    }
+}
+
+impl From<UnexpectedField> for String {
+    #[inline]
+    fn from(value: UnexpectedField) -> Self {
+        match value {
+            UnexpectedField::String(v) => v.0,
+            UnexpectedField::ConcealedString(v) => v.0,
+            UnexpectedField::WifiNetworkSecurityType(v) => match v {
+                EditableFieldWifiNetworkSecurityType::Unsecured => "unsecured".into(),
+                EditableFieldWifiNetworkSecurityType::WpaPersonal => "wpa-personal".into(),
+                EditableFieldWifiNetworkSecurityType::Wpa2Personal => "wpa2-personal".into(),
+                EditableFieldWifiNetworkSecurityType::Wpa3Personal => "wpa3-personal".into(),
+                EditableFieldWifiNetworkSecurityType::Wep => "wep".into(),
+                EditableFieldWifiNetworkSecurityType::Other(o) => o,
+            },
+            UnexpectedField::SubdivisionCode(v) => v.0,
+            UnexpectedField::CountryCode(v) => v.0,
+            UnexpectedField::Unknown { value: v, .. } => v,
+            UnexpectedField::Boolean(b) => if b.0 { "true" } else { "false" }.into(),
+            UnexpectedField::Date(date) => date.0.format("%Y-%m-%d").to_string(),
+            UnexpectedField::YearMonth(v) => v.into(),
+        }
+    }
+}
+
+/// Holds onto an editable field, and records whether it was an expected or unexpected field.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ExpectedInner<T> {
+    /// The field we found had the same field type we expected.
+    Expected(T),
+    /// The field we found had a different field type than what we expected.
+    Unexpected(UnexpectedField),
+}
+
+/// Holds onto an editable field, and records whether it was an expected or unexpected field.
+///
+/// This is used as a type-safe wrapper around an editable field to encode expectations around
+/// the type of field we are expecting in a credential.
+///
+/// This can only be instantiated via the exposed `From` implementation so that newly
+/// constructed credentials remain spec-compliant with regards to their fields.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Expected<T>(ExpectedInner<T>);
+
+impl<T> Expected<T>
+where
+    T: EditableFieldType,
+{
+    /// Returns the real [`FieldType`] of this field.
+    #[inline]
+    pub fn field_type(&self) -> FieldType {
+        match &self.0 {
+            ExpectedInner::Expected(_) => T::field_type(),
+            ExpectedInner::Unexpected(f) => f.field_type(),
+        }
+    }
+
+    /// Tries to return the field type we were expecting.
+    #[inline]
+    pub fn as_expected(&self) -> Result<&T, &UnexpectedField> {
+        match &self.0 {
+            ExpectedInner::Expected(t) => Ok(t),
+            ExpectedInner::Unexpected(f) => Err(f),
+        }
+    }
+
+    /// Tries to return the field type we were expecting as an owned type.
+    #[inline]
+    pub fn into_expected(self) -> Result<T, UnexpectedField> {
+        match self.0 {
+            ExpectedInner::Expected(t) => Ok(t),
+            ExpectedInner::Unexpected(f) => Err(f),
+        }
+    }
+}
+
+impl<T> From<T> for Expected<T> {
+    #[inline]
+    fn from(t: T) -> Self {
+        Self(ExpectedInner::Expected(t))
+    }
+}
+
+impl<T> From<Expected<T>> for String
+where
+    T: Into<String>,
+{
+    #[inline]
+    fn from(value: Expected<T>) -> Self {
+        match value.0 {
+            ExpectedInner::Expected(t) => t.into(),
+            ExpectedInner::Unexpected(f) => f.into(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -62,7 +203,7 @@ pub enum FieldType {
 /// A trait to associate the field structs with their `field_type` tag.
 pub trait EditableFieldType {
     /// The `field_type` value associated with the type
-    fn field_type(&self) -> FieldType;
+    fn field_type() -> FieldType;
 }
 
 impl<T, E> Serialize for EditableField<T, E>
@@ -87,7 +228,27 @@ where
         }
 
         state.serialize_field("fieldType", &self.value.field_type())?;
-        state.serialize_field("value", &self.value)?;
+        match &self.value.0 {
+            ExpectedInner::Expected(t) => {
+                state.serialize_field("value", &t)?;
+            }
+            ExpectedInner::Unexpected(t) => match t {
+                UnexpectedField::String(v) => state.serialize_field("value", &v)?,
+                UnexpectedField::ConcealedString(v) => state.serialize_field("value", &v)?,
+                UnexpectedField::WifiNetworkSecurityType(v) => {
+                    state.serialize_field("value", &v)?
+                }
+                UnexpectedField::SubdivisionCode(v) => state.serialize_field("value", &v)?,
+                UnexpectedField::CountryCode(v) => state.serialize_field("value", &v)?,
+                UnexpectedField::Unknown { value: v, .. } => state.serialize_field("value", &v)?,
+                UnexpectedField::Boolean(b) => {
+                    let v = if b.0 { "true" } else { "false" };
+                    state.serialize_field("value", v)?
+                }
+                UnexpectedField::Date(date) => state.serialize_field("value", &date)?,
+                UnexpectedField::YearMonth(v) => state.serialize_field("value", &v)?,
+            },
+        }
 
         if let Some(ref label) = self.label {
             state.serialize_field("label", label)?;
@@ -109,6 +270,25 @@ where
     }
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EditableFieldHelper<E> {
+    #[serde(default)]
+    id: Option<B64Url>,
+    value: String,
+    field_type: FieldType,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default = "none::<E>")]
+    extensions: Option<Vec<Extension<E>>>,
+}
+
+// Need to use this instead of the normal default,
+// otherwise the derive creates a `E: Default` constraint.
+fn none<E>() -> Option<Vec<Extension<E>>> {
+    None
+}
+
 impl<'de, T, E> Deserialize<'de> for EditableField<T, E>
 where
     T: EditableFieldType + DeserializeOwned,
@@ -118,35 +298,62 @@ where
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct EditableFieldHelper<T, E> {
-            #[serde(default)]
-            id: Option<B64Url>,
-            value: T,
-            field_type: FieldType,
-            #[serde(default)]
-            label: Option<String>,
-            #[serde(default = "none::<E>")]
-            extensions: Option<Vec<Extension<E>>>,
-        }
-        // Need to use this instead of the normal default,
-        // otherwise the derive creates a `E: Default` constraint.
-        fn none<E>() -> Option<Vec<Extension<E>>> {
-            None
-        }
+        let helper: EditableFieldHelper<E> = EditableFieldHelper::deserialize(deserializer)?;
 
-        let helper: EditableFieldHelper<T, E> = EditableFieldHelper::deserialize(deserializer)?;
+        let value = if T::field_type() == helper.field_type {
+            match T::deserialize(StrDeserializer::<serde::de::value::Error>::new(
+                helper.value.as_str(),
+            )) {
+                Ok(t) => ExpectedInner::Expected(t),
+                Err(_) => ExpectedInner::Unexpected(UnexpectedField::Unknown {
+                    field_type: helper.field_type,
+                    value: helper.value,
+                }),
+            }
+        } else {
+            macro_rules! deserialize_from_str {
+                ($t:tt => $variant:ident) => {
+                    match $t::deserialize(StrDeserializer::<D::Error>::new(&helper.value)) {
+                        Ok(v) => UnexpectedField::$variant(v),
+                        _ => UnexpectedField::Unknown {
+                            field_type: helper.field_type,
+                            value: helper.value,
+                        },
+                    }
+                };
+            }
 
-        if helper.field_type != helper.value.field_type() {
-            return Err(serde::de::Error::custom(
-                "field_type does not match value type",
-            ));
-        }
+            let value = match helper.field_type {
+                FieldType::String => UnexpectedField::String(EditableFieldString(helper.value)),
+                FieldType::ConcealedString => {
+                    UnexpectedField::ConcealedString(EditableFieldConcealedString(helper.value))
+                }
+                FieldType::Boolean => deserialize_from_str!(EditableFieldBoolean => Boolean),
+                FieldType::Date => deserialize_from_str!(EditableFieldDate => Date),
+                FieldType::YearMonth => deserialize_from_str!(EditableFieldYearMonth => YearMonth),
+                FieldType::WifiNetworkSecurityType => {
+                    deserialize_from_str!(EditableFieldWifiNetworkSecurityType => WifiNetworkSecurityType)
+                }
+                FieldType::SubdivisionCode => {
+                    UnexpectedField::SubdivisionCode(EditableFieldSubdivisionCode(helper.value))
+                }
+                FieldType::CountryCode => {
+                    UnexpectedField::CountryCode(EditableFieldCountryCode(helper.value))
+                }
+                FieldType::Email | FieldType::Number | FieldType::Unknown(_) => {
+                    UnexpectedField::Unknown {
+                        field_type: helper.field_type,
+                        value: helper.value,
+                    }
+                }
+            };
+
+            ExpectedInner::Unexpected(value)
+        };
 
         Ok(Self {
             id: helper.id,
-            value: helper.value,
+            value: Expected(value),
             label: helper.label,
             extensions: helper.extensions,
         })
@@ -158,7 +365,7 @@ impl<T, E> From<T> for EditableField<T, E> {
     fn from(s: T) -> Self {
         EditableField {
             id: None,
-            value: s,
+            value: s.into(),
             label: None,
             extensions: None,
         }
@@ -174,12 +381,20 @@ macro_rules! editable_field_string_type {
         pub struct $name(pub String);
 
         impl EditableFieldType for $name {
-            fn field_type(&self) -> FieldType {
+            fn field_type() -> FieldType {
                 FieldType::$variant
             }
         }
 
+        impl From<String> for $name {
+            #[inline]
+            fn from(s: String) -> Self {
+                $name(s)
+            }
+        }
+
         impl<E> From<String> for EditableField<$name, E> {
+            #[inline]
             fn from(s: String) -> Self {
                 $name(s).into()
             }
@@ -187,7 +402,17 @@ macro_rules! editable_field_string_type {
 
         impl<E> From<EditableField<$name, E>> for String {
             fn from(s: EditableField<$name, E>) -> Self {
-                s.value.0
+                match s.value.0 {
+                    ExpectedInner::Expected(f) => f.0.into(),
+                    ExpectedInner::Unexpected(f) => f.into(),
+                }
+            }
+        }
+
+        impl AsRef<str> for $name {
+            #[inline]
+            fn as_ref(&self) -> &str {
+                &self.0
             }
         }
     };
@@ -200,10 +425,11 @@ editable_field_string_type!(EditableFieldNumber, Number);
 editable_field_string_type!(EditableFieldSubdivisionCode, SubdivisionCode);
 editable_field_string_type!(EditableFieldCountryCode, CountryCode);
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
 pub struct EditableFieldBoolean(#[serde(with = "serde_bool")] pub bool);
 impl EditableFieldType for EditableFieldBoolean {
-    fn field_type(&self) -> FieldType {
+    fn field_type() -> FieldType {
         FieldType::Boolean
     }
 }
@@ -214,44 +440,34 @@ impl<E> From<bool> for EditableField<EditableFieldBoolean, E> {
     }
 }
 
-impl<E> From<EditableField<EditableFieldBoolean, E>> for bool {
-    fn from(b: EditableField<EditableFieldBoolean, E>) -> Self {
-        b.value.0
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct EditableFieldDate(pub NaiveDate);
 impl EditableFieldType for EditableFieldDate {
-    fn field_type(&self) -> FieldType {
+    fn field_type() -> FieldType {
         FieldType::Date
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(into = "String")]
 pub struct EditableFieldYearMonth {
     /// The year in the format `YYYY`
     pub year: u16,
     /// The month in the format `MM`
     pub month: Month,
 }
-impl EditableFieldType for EditableFieldYearMonth {
-    fn field_type(&self) -> FieldType {
-        FieldType::YearMonth
+
+impl From<EditableFieldYearMonth> for String {
+    #[inline]
+    fn from(value: EditableFieldYearMonth) -> String {
+        format!("{:04}-{:02}", value.year, value.month.number_from_month())
     }
 }
 
-impl Serialize for EditableFieldYearMonth {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&format!(
-            "{:04}-{:02}",
-            self.year,
-            self.month.number_from_month()
-        ))
+impl EditableFieldType for EditableFieldYearMonth {
+    fn field_type() -> FieldType {
+        FieldType::YearMonth
     }
 }
 
@@ -323,13 +539,13 @@ pub enum EditableFieldWifiNetworkSecurityType {
     Other(String),
 }
 impl EditableFieldType for EditableFieldWifiNetworkSecurityType {
-    fn field_type(&self) -> FieldType {
+    fn field_type() -> FieldType {
         FieldType::WifiNetworkSecurityType
     }
 }
 
 /// Helper wrapper for `CustomFieldsCredential`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(untagged, bound(deserialize = "E: Deserialize<'de>"))]
 #[non_exhaustive]
 pub enum EditableFieldValue<E = ()> {
@@ -345,9 +561,56 @@ pub enum EditableFieldValue<E = ()> {
     WifiNetworkSecurityType(EditableField<EditableFieldWifiNetworkSecurityType, E>),
 }
 
-mod serde_bool {
-    use serde::Deserialize;
+impl<'de, E> Deserialize<'de> for EditableFieldValue<E>
+where
+    E: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let helper: EditableFieldHelper<E> = EditableFieldHelper::deserialize(deserializer)?;
 
+        macro_rules! deserialize_field {
+            ($t: tt) => {{
+                let v = $t::deserialize(StringDeserializer::new(helper.value))?;
+
+                EditableField {
+                    id: helper.id,
+                    value: Expected(ExpectedInner::Expected(v)),
+                    label: helper.label,
+                    extensions: helper.extensions,
+                }
+            }};
+        }
+
+        let res = match helper.field_type {
+            FieldType::String => Self::String(deserialize_field!(EditableFieldString)),
+            FieldType::ConcealedString => {
+                Self::ConcealedString(deserialize_field!(EditableFieldConcealedString))
+            }
+            FieldType::Boolean => Self::Boolean(deserialize_field!(EditableFieldBoolean)),
+            FieldType::Date => Self::Date(deserialize_field!(EditableFieldDate)),
+            FieldType::YearMonth => Self::YearMonth(deserialize_field!(EditableFieldYearMonth)),
+            FieldType::WifiNetworkSecurityType => Self::WifiNetworkSecurityType(
+                deserialize_field!(EditableFieldWifiNetworkSecurityType),
+            ),
+            FieldType::SubdivisionCode => {
+                Self::SubdivisionCode(deserialize_field!(EditableFieldSubdivisionCode))
+            }
+            FieldType::CountryCode => {
+                Self::CountryCode(deserialize_field!(EditableFieldCountryCode))
+            }
+            FieldType::Email | FieldType::Number | FieldType::Unknown(_) => {
+                return Err(serde::de::Error::custom("Unknown custom field type"))
+            }
+        };
+
+        Ok(res)
+    }
+}
+
+mod serde_bool {
     pub fn serialize<S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -359,10 +622,9 @@ mod serde_bool {
     where
         D: serde::Deserializer<'de>,
     {
-        let value = <&str>::deserialize(deserializer)?;
+        let s = deserializer.deserialize_str(super::CowVisitor)?;
 
-        value
-            .trim()
+        s.trim()
             .to_lowercase()
             .parse()
             .map_err(serde::de::Error::custom)
@@ -379,7 +641,7 @@ mod tests {
     fn test_serialize_editable_field_string() {
         let field: EditableField<EditableFieldString> = EditableField {
             id: None,
-            value: EditableFieldString("value".to_string()),
+            value: EditableFieldString("value".to_string()).into(),
             label: Some("label".to_string()),
             extensions: None,
         };
@@ -404,7 +666,7 @@ mod tests {
             field,
             EditableField {
                 id: None,
-                value: EditableFieldString("value".to_string()),
+                value: EditableFieldString("value".to_string()).into(),
                 label: Some("label".to_string()),
                 extensions: None,
             }
@@ -415,7 +677,7 @@ mod tests {
     fn test_serialize_field_concealed_string() {
         let field: EditableField<EditableFieldConcealedString> = EditableField {
             id: None,
-            value: EditableFieldConcealedString("value".to_string()),
+            value: EditableFieldConcealedString("value".to_string()).into(),
             label: Some("label".to_string()),
             extensions: None,
         };
@@ -437,7 +699,7 @@ mod tests {
         let field: Result<EditableField<EditableFieldConcealedString>, _> =
             serde_json::from_value(json);
 
-        assert!(field.is_err());
+        assert!(field.unwrap().value.as_expected().is_err());
     }
 
     #[test]
@@ -461,7 +723,7 @@ mod tests {
         });
         let field: Result<EditableField<EditableFieldBoolean>, _> = serde_json::from_value(json);
 
-        assert!(field.is_err());
+        assert!(field.unwrap().value.as_expected().is_err());
     }
 
     #[test]
@@ -490,7 +752,7 @@ mod tests {
             field,
             EditableField {
                 id: None,
-                value: EditableFieldConcealedString("value".to_string()),
+                value: EditableFieldConcealedString("value".to_string()).into(),
                 label: Some("label".to_string()),
                 extensions: None,
             }
@@ -501,7 +763,7 @@ mod tests {
     fn test_serialize_field_boolean() {
         let field: EditableField<EditableFieldBoolean> = EditableField {
             id: None,
-            value: EditableFieldBoolean(true),
+            value: EditableFieldBoolean(true).into(),
             label: Some("label".to_string()),
             extensions: None,
         };
@@ -517,7 +779,7 @@ mod tests {
     fn test_serialize_field_date() {
         let field: EditableField<EditableFieldDate> = EditableField {
             id: None,
-            value: EditableFieldDate(NaiveDate::from_ymd_opt(2025, 2, 24).unwrap()),
+            value: EditableFieldDate(NaiveDate::from_ymd_opt(2025, 2, 24).unwrap()).into(),
             label: None,
             extensions: None,
         };
@@ -535,7 +797,8 @@ mod tests {
             value: EditableFieldYearMonth {
                 year: 2025,
                 month: Month::February,
-            },
+            }
+            .into(),
             label: None,
             extensions: None,
         };
@@ -561,7 +824,8 @@ mod tests {
                 value: EditableFieldYearMonth {
                     year: 2025,
                     month: Month::February,
-                },
+                }
+                .into(),
                 label: None,
                 extensions: None,
             }
@@ -574,8 +838,14 @@ mod tests {
             "fieldType": "year-month",
             "value": "2025/02",
         });
-        let field: Result<EditableField<EditableFieldYearMonth>, _> = serde_json::from_value(json);
-        assert!(field.is_err());
+        let field: EditableField<EditableFieldYearMonth> = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            field.value.as_expected(),
+            Err(&UnexpectedField::Unknown {
+                field_type: FieldType::YearMonth,
+                value: "2025/02".into(),
+            })
+        );
     }
 
     #[test]
@@ -603,7 +873,7 @@ mod tests {
             field,
             EditableField {
                 id: None,
-                value: EditableFieldString("hello".to_string()),
+                value: EditableFieldString("hello".to_string()).into(),
                 label: None,
                 extensions: Some(vec![Extension::External(CustomExtension::Test {
                     contents: "world".into()
@@ -614,5 +884,39 @@ mod tests {
         let returned = serde_json::to_value(field).expect("Could not serialize custom extensions");
 
         assert_eq!(returned, json);
+    }
+
+    #[test]
+    fn editable_string_deserialized_from_others() {
+        for (field_type, expected) in [
+            (
+                "concealed-string",
+                UnexpectedField::ConcealedString("hello".to_owned().into()),
+            ),
+            (
+                "unknown",
+                UnexpectedField::Unknown {
+                    field_type: FieldType::Unknown("unknown".into()),
+                    value: "hello".into(),
+                },
+            ),
+            (
+                "date",
+                UnexpectedField::Unknown {
+                    field_type: FieldType::Date,
+                    value: "hello".into(),
+                },
+            ),
+        ] {
+            let json = json!({
+                "fieldType": field_type,
+                "value": "hello",
+            });
+
+            let field: EditableField<EditableFieldString> =
+                serde_json::from_value(json.clone()).expect("Could not deserialize field");
+
+            assert_eq!(field.value.into_expected(), Err(expected));
+        }
     }
 }

--- a/credential-exchange-format/src/editable_field.rs
+++ b/credential-exchange-format/src/editable_field.rs
@@ -43,6 +43,8 @@ pub enum UnexpectedField {
     SubdivisionCode(EditableFieldSubdivisionCode),
     CountryCode(EditableFieldCountryCode),
     WifiNetworkSecurityType(EditableFieldWifiNetworkSecurityType),
+    Email(EditableFieldEmail),
+    Number(EditableFieldNumber),
     Unknown {
         /// The unexpected field type.
         field_type: FieldType,
@@ -66,6 +68,8 @@ impl UnexpectedField {
             Self::SubdivisionCode(_) => EditableFieldSubdivisionCode::field_type(),
             Self::CountryCode(_) => EditableFieldCountryCode::field_type(),
             Self::WifiNetworkSecurityType(_) => EditableFieldWifiNetworkSecurityType::field_type(),
+            Self::Email(_) => EditableFieldEmail::field_type(),
+            Self::Number(_) => EditableFieldNumber::field_type(),
             Self::Unknown { field_type, .. } => field_type.clone(),
         }
     }
@@ -88,6 +92,8 @@ impl From<UnexpectedField> for String {
             UnexpectedField::SubdivisionCode(v) => v.0,
             UnexpectedField::CountryCode(v) => v.0,
             UnexpectedField::Unknown { value: v, .. } => v,
+            UnexpectedField::Email(v) => v.0,
+            UnexpectedField::Number(v) => v.0,
             UnexpectedField::Boolean(b) => if b.0 { "true" } else { "false" }.into(),
             UnexpectedField::Date(date) => date.0.format("%Y-%m-%d").to_string(),
             UnexpectedField::YearMonth(v) => v.into(),
@@ -247,6 +253,8 @@ where
                 }
                 UnexpectedField::Date(date) => state.serialize_field("value", &date)?,
                 UnexpectedField::YearMonth(v) => state.serialize_field("value", &v)?,
+                UnexpectedField::Email(v) => state.serialize_field("value", &v)?,
+                UnexpectedField::Number(v) => state.serialize_field("value", &v)?,
             },
         }
 
@@ -340,12 +348,12 @@ where
                 FieldType::CountryCode => {
                     UnexpectedField::CountryCode(EditableFieldCountryCode(helper.value))
                 }
-                FieldType::Email | FieldType::Number | FieldType::Unknown(_) => {
-                    UnexpectedField::Unknown {
-                        field_type: helper.field_type,
-                        value: helper.value,
-                    }
-                }
+                FieldType::Email => UnexpectedField::Email(EditableFieldEmail(helper.value)),
+                FieldType::Number => UnexpectedField::Number(EditableFieldNumber(helper.value)),
+                FieldType::Unknown(_) => UnexpectedField::Unknown {
+                    field_type: helper.field_type,
+                    value: helper.value,
+                },
             };
 
             ExpectedInner::Unexpected(value)
@@ -601,7 +609,9 @@ where
             FieldType::CountryCode => {
                 Self::CountryCode(deserialize_field!(EditableFieldCountryCode))
             }
-            FieldType::Email | FieldType::Number | FieldType::Unknown(_) => {
+            FieldType::Email => Self::Email(deserialize_field!(EditableFieldEmail)),
+            FieldType::Number => Self::Number(deserialize_field!(EditableFieldNumber)),
+            FieldType::Unknown(_) => {
                 return Err(serde::de::Error::custom("Unknown custom field type"))
             }
         };

--- a/credential-exchange-format/src/editable_field.rs
+++ b/credential-exchange-format/src/editable_field.rs
@@ -88,7 +88,7 @@ impl From<UnexpectedField> for String {
             UnexpectedField::Email(v) => v.0,
             UnexpectedField::Number(v) => v.0,
             UnexpectedField::Boolean(v) => v.into(),
-            UnexpectedField::Date(date) => date.0.format("%Y-%m-%d").to_string(),
+            UnexpectedField::Date(v) => v.into(),
             UnexpectedField::YearMonth(v) => v.into(),
         }
     }
@@ -454,6 +454,13 @@ pub struct EditableFieldDate(pub NaiveDate);
 impl EditableFieldType for EditableFieldDate {
     fn field_type() -> FieldType {
         FieldType::Date
+    }
+}
+
+impl From<EditableFieldDate> for String {
+    #[inline]
+    fn from(value: EditableFieldDate) -> Self {
+        value.0.format("%Y-%m-%d").to_string()
     }
 }
 

--- a/credential-exchange-format/src/lib.rs
+++ b/credential-exchange-format/src/lib.rs
@@ -213,11 +213,11 @@ mod tests {
     #[test]
     fn deserializes_unknown_credential() {
         let cred = r#"{ "type": "future-credential" }"#;
-        let res = serde_json::from_str::<Credential>(&cred);
+        let res = serde_json::from_str::<Credential>(cred);
         assert!(matches!(res, Ok(Credential::Unknown { .. })));
 
         let empty = r#"{ }"#;
-        let res = serde_json::from_str::<Credential>(&empty);
+        let res = serde_json::from_str::<Credential>(empty);
         assert!(res.is_err());
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

Solves #122 

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Follow-up from our discussion on https://github.com/bitwarden/credential-exchange/pull/126. Let me know what you think!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
