### PR TITLE
[BRE] Migrate publish workflow to deploy repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,123 +18,29 @@ on:
         type: string
         default: latest
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  setup:
-    name: Setup
+  trigger:
+    name: Trigger publish
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-
-    outputs:
-      release-version: ${{ steps.version-output.outputs.version }}
-      release-tag: ${{ steps.version-output.outputs.tag_name }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
       - name: Branch check
         if: ${{ inputs.release_type != 'Dry Run' }}
         run: |
           if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
             echo "==================================="
-            echo "[!] Can only publish from the 'main' branch"
+            echo "::error::Can only publish from the 'main' branch"
             echo "==================================="
             exit 1
           fi
 
-      - name: Version output
-        id: version-output
-        env:
-          _INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          if [[ "$_INPUT_VERSION" == "latest" || "$_INPUT_VERSION" == "" ]]; then
-            TAG_NAME=$(curl "https://api.github.com/repos/bitwarden/credential-exchange/releases" | jq -c '.[] | .tag_name' | head -1)
-            VERSION=$(echo "$TAG_NAME" | grep -ohE '20[0-9]{2}\.([1-9]|1[0-2])\.[0-9]+')
-            echo "Latest Released Version: $VERSION"
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-            echo "Latest Released Tag name: $TAG_NAME"
-            echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
-          else
-            echo "Release Version: $_INPUT_VERSION"
-            echo "version=$_INPUT_VERSION" >> "$GITHUB_OUTPUT"
-          fi
-
-  publish:
-    name: Publish
-    runs-on: ubuntu-24.04
-    needs: setup
-    permissions:
-      contents: read
-      id-token: write
-      deployments: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Trigger deploy
+        uses: bitwarden/gh-actions/trigger-actions@main
         with:
-          ref: ${{ needs.setup.outputs.release-tag }}
-          persist-credentials: false
-
-      - name: Log in to Azure
-        uses: bitwarden/gh-actions/azure-login@main
-        with:
-          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          client_id: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: "bitwarden-ci"
-          secrets: "cratesio-api-token"
-
-      - name: Log out from Azure
-        uses: bitwarden/gh-actions/azure-logout@main
-
-      - name: Install rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: stable
-
-      - name: Cache cargo registry
-        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
-
-      - name: Install cargo-release
-        run: cargo install cargo-release
-
-      - name: Create GitHub deployment
-        if: ${{ inputs.release_type != 'Dry Run' }}
-        uses: chrnorm/deployment-action@55729fcebec3d284f60f5bcabbd8376437d696b1 # v2.0.7
-        id: deployment
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          initial-status: "in_progress"
-          environment: "crates.io"
-          description: "Deployment from branch ${{ github.ref_name }}"
-          task: release
-
-      - name: Cargo release
-        if: ${{ inputs.release_type != 'Dry Run' }}
-        env:
-          PUBLISH_GRACE_SLEEP: 10
-          CARGO_REGISTRY_TOKEN: ${{ steps.retrieve-secrets.outputs.cratesio-api-token }}
-        run: cargo-release release publish --execute --no-confirm
-
-      - name: Update deployment status to Success
-        if: ${{ inputs.release_type != 'Dry Run' && success() }}
-        uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806 # v2.0.3
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          state: "success"
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
-      - name: Update deployment status to Failure
-        if: ${{ inputs.release_type != 'Dry Run' && failure() }}
-        uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806 # v2.0.3
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          state: "failure"
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          task: publish-credential-exchange-rust-crates


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-2001](https://bitwarden.atlassian.net/browse/BRE-2001)

## 📔 Objective
The `publish.yml` workflow no longer has access to the API key necessary to publish to `crates.io`.
This PR migrates the publish logic to the `deploy` repo, and rewrites the local publish workflow into a trigger for the `deploy` repo workflow that performs the publishing.

[BRE-2001]: https://bitwarden.atlassian.net/browse/BRE-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ