### PR TITLE
Change owner to tools team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default file owners
-* @bitwarden/dept-architecture
+* @bitwarden/team-tools-dev
 
 # Docker-related files
 **/Dockerfile @bitwarden/team-appsec @bitwarden/dept-bre


### PR DESCRIPTION
## 🎟️ Tracking

Slack discussions.

## 📔 Objective

Changes ownership from architecture to the tools team.
