### PR TITLE
[BRE-1935] Migrate workflow: release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,45 +13,22 @@ on:
           - Release
           - Dry Run
 
+permissions:
+  contents: read
+
 jobs:
-  setup:
-    name: Setup
+  trigger-release:
+    name: Trigger Release
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
-    outputs:
-      release-version: ${{ steps.version.outputs.version }}
+      contents: read
+      deployments: write
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Trigger release via bitwarden/deploy
+        uses: bitwarden/gh-actions/trigger-actions@main
         with:
-          persist-credentials: false
-
-      - name: Branch check
-        if: ${{ inputs.release_type != 'Dry Run' }}
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "==================================="
-            echo "[!] Can only release from the 'main' branch"
-            echo "==================================="
-            exit 1
-          fi
-
-      - name: Get version
-        id: version
-        run: |
-          VERSION=$(grep -o '^version = ".*"' Cargo.toml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Create release
-        if: ${{ inputs.release_type != 'Dry Run' }}
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
-        env:
-          PKG_VERSION: ${{ steps.version.outputs.version }}
-        with:
-          commit: ${{ github.sha }}
-          tag: v${{ env.PKG_VERSION }}
-          name: v${{ env.PKG_VERSION }}
-          body: "<insert release notes here>"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true
+          task: release-credential-exchange
+          data: |
+            {
+              "release_type": "${{ inputs.release_type }}"
+            }


### PR DESCRIPTION
## Summary

This PR replaces the release workflow with a trigger-actions caller to `bitwarden/deploy`.

**Part of BRE-1935 Phase 2/3** - The release workflow was migrated to `bitwarden/deploy` in [PR #263](https://github.com/bitwarden/deploy/pull/263). This PR updates the source workflow to invoke it.

## Changes

### Preserved
- ✅ `workflow_dispatch` trigger with `release_type` input (Release/Dry Run)
- ✅ Workflow name and run-name
- ✅ Same manual trigger behavior for developers

### Replaced
- ❌ Removed 37 lines of release logic (checkout, branch check, version extraction, ncipollo/release-action)
- ✅ Added trigger-actions caller (14 lines) that invokes `release-credential-exchange.yml` in `bitwarden/deploy`

## Workflow Flow

1. Developer runs `gh workflow run release.yml --repo bitwarden/credential-exchange -f release_type=Release`
2. This workflow calls `bitwarden/gh-actions/trigger-actions` with:
   - `task: release-credential-exchange`
   - `data.release_type`: Release or Dry Run
3. The deployment event is received by `trigger-actions.yml` in `bitwarden/deploy` and routed to `release-credential-exchange.yml` (Phase 3 will wire up the receiver)

## Testing

After Phase 3 (wire-trigger) is complete:
- `gh workflow run release.yml -f release_type=Release` should create a draft release on this repo
- `gh workflow run release.yml -f release_type="Dry Run"` should run without creating the release

## Next Steps

Phase 3 (wire-trigger): Add receiver job to `trigger-actions.yml` in `bitwarden/deploy` for task `release-credential-exchange`.